### PR TITLE
Add basic acceptance testing in Github actions

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,11 +1,8 @@
 name: Acceptance
 on:
-  pull_request:
-    branches:
-    - master
   push:
     branches:
-    - master
+    - "*"
   schedule:
     - cron: "0 0 * * *"
 
@@ -24,10 +21,12 @@ jobs:
 
     - uses: actions/checkout@master
 
-    - name: Turnstyle
+    - name: Wait for previous workflows to complete
       uses: softprops/turnstyle@v1
       env:
         GITHUB_TOKEN: ${{ secrets.TURNSTYLE_TOKEN }}
+      with:
+        poll-interval-seconds: 10
 
     - name: Run tests
       run: |

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,6 +14,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Install Go 1.14
       uses: actions/setup-go@v1
@@ -22,6 +23,11 @@ jobs:
       id: go
 
     - uses: actions/checkout@master
+
+    - name: Turnstyle
+      uses: softprops/turnstyle@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.TURNSTYLE_TOKEN }}
 
     - name: Run tests
       run: |

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,0 +1,31 @@
+name: Acceptance
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+
+    - uses: actions/checkout@master
+
+    - name: Run tests
+      run: |
+        TF_ACC=1 go test -v ./... -timeout=30m
+      env:
+        CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        CLOUDSMITH_NAMESPACE: terraform-provider-testing


### PR DESCRIPTION
This PR adds a Github Actions config to run acceptance tests on every PR to master and on an overnight schedule to ensure the provider continues to work as expected.