### PR TITLE
Add basic documentation for display in Terraform registry

### DIFF
--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -1,0 +1,26 @@
+# Namespace Data Source
+
+The `namespace` data source allows fetching of metadata about a given Cloudsmith namespace. The fetched data can be used to resolve permanent identifiers from a namespace's user-facing name. These identifiers can then be passed to other resources to allow more consistent identification as user-facing names can change.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_namespace" "my_namespace" {
+    slug = "my-namespace"
+}
+```
+
+## Argument Reference
+
+* `slug` - (Required) The slug identifies the namespace in URIs.
+
+## Attribute Reference
+
+* `name` - A descriptive name for the namespace.
+* `slug` - The slug identifies the namespace in URIs.
+* `slug_perm` - The slug_perm immutably identifies the namespace. It will never change once a namespace has been created.
+* `type_name` - Is this a user or an organization namespace?.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,35 @@
+# Cloudsmith Provider
+
+This provider allows Cloudsmith users to automate the provisioning of resources using Terraform. Users can create and manage repositories, along with entitlement tokens to grant access to repository contents.
+
+See [help.cloudsmith.io](https://help.cloudsmith.io/) for full documentation (including an API reference).
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_namespace" "my_namespace" {
+    slug = "my-namespace"
+}
+
+resource "cloudsmith_repository" "my_repository" {
+    description = "A certifiably-awesome private package repository"
+    name        = "My Repository"
+    namespace   = "${data.cloudsmith_namespace.my_namespace.slug_perm}"
+    slug        = "my-repository"
+}
+
+resource "cloudsmith_entitlement" "my_entitlement" {
+    name       = "Test Entitlement"
+    namespace  = "${cloudsmith_repository.test.namespace}"
+    repository = "${cloudsmith_repository.test.slug_perm}"
+}
+```
+
+## Argument Reference
+
+* `api_key` - (Required) The API key for authenticating with the Cloudsmith API.
+* `api_host` - (Optional) The API host to connect to (used to connect to a non-production Cloudsmith instance, mostly useful for testing).

--- a/docs/resources/entitlement.md
+++ b/docs/resources/entitlement.md
@@ -1,0 +1,58 @@
+# Entitlement Resource
+
+The entitlement resource allows the creation and management of Entitlement tokens for a given Cloudsmith repository. Entitlement tokens grant read-only access to a repository and can be configured with a number of custom restrictions if necessary.
+
+See [help.cloudsmith.io](https://help.cloudsmith.io/docs/entitlements) for full entitlement documentation.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_namespace" "my_namespace" {
+    slug = "my-namespace"
+}
+
+resource "cloudsmith_repository" "my_repository" {
+    description = "A certifiably-awesome private package repository"
+    name        = "My Repository"
+    namespace   = "${data.cloudsmith_namespace.my_namespace.slug_perm}"
+    slug        = "my-repository"
+}
+
+resource "cloudsmith_entitlement" "my_entitlement" {
+    name       = "Test Entitlement"
+    namespace  = "${cloudsmith_repository.test.namespace}"
+    repository = "${cloudsmith_repository.test.slug_perm}"
+}
+```
+
+## Argument Reference
+
+* `is_active` - (Optional) If enabled, the token will allow downloads based on configured restrictions (if any).
+* `limit_date_range_from` - (Optional) The starting date/time the token is allowed to be used from.
+* `limit_date_range_to` - (Optional) The ending date/time the token is allowed to be used until.
+* `limit_num_clients` - (Optional) The maximum number of unique clients allowed for the token. Please note that since clients are calculated asynchronously (after the download happens), the limit may not be imposed immediately but at a later point.
+* `limit_num_downloads` - (Optional) The maximum number of downloads allowed for the token. Please note that since downloads are calculated asynchronously (after the download happens), the limit may not be imposed immediately but at a later point.
+* `limit_package_query` - (Optional) The package-based search query to apply to restrict downloads to. This uses the same syntax as the standard search used for repositories, and also supports boolean logic operators such as OR/AND/NOT and parentheses for grouping. This will still allow access to non-package files, such as metadata.
+* `limit_path_query` - (Optional) The path-based search query to apply to restrict downloads to. This supports boolean logic operators such as OR/AND/NOT and parentheses for grouping. The path evaluated does not include the domain name, the namespace, the entitlement code used, the package format, etc. and it always starts with a forward slash.
+* `name` - (Required) A descriptive name for the entitlement.
+* `namespace` - (Required) Namespace to which this entitlement belongs.
+* `repository` - (Required) Repository to which this entitlement belongs.
+* `token` - (Optional) The literal value of the token to be created.
+
+## Attribute Reference
+
+* `is_active` - If enabled, the token will allow downloads based on configured restrictions (if any).
+* `limit_date_range_from` - The starting date/time the token is allowed to be used from.
+* `limit_date_range_to` - The ending date/time the token is allowed to be used until.
+* `limit_num_clients` - The maximum number of unique clients allowed for the token. Please note that since clients are calculated asynchronously (after the download happens), the limit may not be imposed immediately but at a later point.
+* `limit_num_downloads` - The maximum number of downloads allowed for the token. Please note that since downloads are calculated asynchronously (after the download happens), the limit may not be imposed immediately but at a later point.
+* `limit_package_query` - The package-based search query to apply to restrict downloads to. This uses the same syntax as the standard search used for repositories, and also supports boolean logic operators such as OR/AND/NOT and parentheses for grouping. This will still allow access to non-package files, such as metadata.
+* `limit_path_query` - The path-based search query to apply to restrict downloads to. This supports boolean logic operators such as OR/AND/NOT and parentheses for grouping. The path evaluated does not include the domain name, the namespace, the entitlement code used, the package format, etc. and it always starts with a forward slash.
+* `name` - A descriptive name for the entitlement.
+* `namespace` - Namespace to which this entitlement belongs.
+* `repository` - Repository to which this entitlement belongs.
+* `token` - The literal value of the token to be created.

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -1,0 +1,53 @@
+# Repository Resource
+
+The repository resource allows creation and management of package repositories within a Cloudsmith namespace. Repositories store packages and are the main entities with which Cloudsmith users interact.
+
+See [help.cloudsmith.io](https://help.cloudsmith.io/docs/manage-a-repository) for full repository documentation.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_namespace" "my_namespace" {
+    slug = "my-namespace"
+}
+
+resource "cloudsmith_repository" "my_repository" {
+    description = "A certifiably-awesome private package repository"
+    name        = "My Repository"
+    namespace   = "${data.cloudsmith_namespace.my_namespace.slug_perm}"
+    slug        = "my-repository"
+}
+```
+
+## Argument Reference
+
+* `description` - (Optional) A description of the repository's purpose/contents.
+* `index_files` - (Optional) If checked, files contained in packages will be indexed, which increase the synchronisation time required for packages. Note that it is recommended you keep this enabled unless the synchronisation time is significantly impacted.
+* `name` - (Required) A descriptive name for the repository.
+* `namespace` - (Required) Namespace to which this repository belongs.
+* `repository_type` - (Optional) The repository type changes how it is accessed and billed. Private repositories can only be used on paid plans, but are visible only to you or authorised delegates. Public repositories are free to use on all plans and visible to all Cloudsmith users.
+* `slug` - (Optional) The slug identifies the repository in URIs.
+* `storage_region` - (Optional) The Cloudsmith region in which package files are stored.
+* `wait_for_deletion` - (Optional) If true, terraform will wait for a repository to be permanently deleted before finishing.
+
+## Attribute Reference
+
+* `cdn_url` - Base URL from which packages and other artifacts are downloaded.
+* `created_at` - ISO 8601 timestamp at which the repository was created.
+* `deleted_at` - ISO 8601 timestamp at which the repository was deleted (repositories are soft deleted temporarily to allow cancelling).
+* `description` - A description of the repository's purpose/contents.
+* `index_files` - If checked, files contained in packages will be indexed, which increase the synchronisation time required for packages. Note that it is recommended you keep this enabled unless the synchronisation time is significantly impacted.
+* `name` - A descriptive name for the repository.
+* `namespace` - Namespace to which this repository belongs.
+* `namespace_url` - API endpoint where data about this namespace can be retrieved.
+* `repository_type` - The repository type changes how it is accessed and billed. Private repositories can only be used on paid plans, but are visible only to you or authorised delegates. Public repositories are free to use on all plans and visible to all Cloudsmith users.
+* `self_html_url` - Website URL for this repository.
+* `self_url` - API endpoint where data about this repository can be retrieved.
+* `slug` - The slug identifies the repository in URIs.
+* `slug_perm` - The slug_perm immutably identifies the repository. It will never change once a repository has been created.
+* `storage_region` - The Cloudsmith region in which package files are stored.
+* `wait_for_deletion` - If true, terraform will wait for a repository to be permanently deleted before finishing.


### PR DESCRIPTION
This PR adds basic documentation required for display in the Terraform registry (with links back to help.cloudsmith.io).