### PR TITLE
Add a datasource for retrieving repositories and packages from Cloudsmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,43 @@ data "cloudsmith_namespace" "my_namespace" {
 resource "cloudsmith_repository" "my_repository" {
     description = "A certifiably-awesome private package repository"
     name        = "My Repository"
-    namespace   = "${data.cloudsmith_namespace.my_namespace.slug_perm}"
+    namespace   = data.cloudsmith_namespace.my_namespace.slug_perm
     slug        = "my-repository"
 }
 
 resource "cloudsmith_entitlement" "my_entitlement" {
     name       = "Test Entitlement"
-    namespace  = "${cloudsmith_repository.test.namespace}"
-    repository = "${cloudsmith_repository.test.slug_perm}"
+    namespace  = cloudsmith_repository.test.namespace
+    repository = cloudsmith_repository.test.slug_perm
+}
+```
+
+
+Retrieve a list of packages from a repository
+
+```
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_namespace" "my_namespace" {
+  slug = "my-namespace"
+}
+
+data "cloudsmith_repository" "my_repository" {
+  namespace = data.cloudsmith_namespace.my_namespace.slug
+  name      = "My Repository"
+}
+
+data "cloudsmith_packages" "my_packages" {
+  namespace     = data.cloudsmith_repository.my_repository.namespace
+  repository    = data.cloudsmith_repository.my_repository.slug
+  package_group = "my-package"
+  filters       = ["format:docker"]
+}
+
+output "packages" {
+  value = formatlist("%s-%s", data.cloudsmith_packages.my_packages.packages.*.name, data.cloudsmith_packages.my_packages.packages.*.version)
 }
 ```
 

--- a/cloudsmith/data_source_packages.go
+++ b/cloudsmith/data_source_packages.go
@@ -1,6 +1,9 @@
 package cloudsmith
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
@@ -23,6 +26,8 @@ func dataSourcePackagesRead(d *schema.ResourceData, m interface{}) error {
 	if err := d.Set("package", packages); err != nil {
 		return err
 	}
+
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 
 	return nil
 }

--- a/cloudsmith/data_source_packages.go
+++ b/cloudsmith/data_source_packages.go
@@ -1,0 +1,143 @@
+package cloudsmith
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/cloudsmith-io/cloudsmith-api-go"
+)
+
+func dataSourcePackagesRead(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	namespace := d.Get("namespace").(string)
+	repository := d.Get("repository").(string)
+	optional := cloudsmith.PackagesListOpts{}
+
+	packagesList, _, err := pc.APIClient.PackagesApi.PackagesList(pc.Auth, namespace, repository, &optional)
+	if err != nil {
+		return err
+	}
+
+	packages := flattenPackages(&packagesList)
+	if err := d.Set("package", packages); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func flattenPackages(packages *[]cloudsmith.Package) []interface{} {
+	if packages != nil {
+		pkgs := make([]interface{}, len(*packages), len(*packages))
+		for i, packageItem := range *packages {
+			pkg := make(map[string]interface{})
+			pkg["repository"] = packageItem.Repository
+			pkg["namespace"] = packageItem.Namespace
+			pkg["name"] = packageItem.Name
+			pkg["slug"] = packageItem.Slug
+			pkg["slug_perm"] = packageItem.SlugPerm
+			pkg["format"] = packageItem.Format
+			pkg["version"] = packageItem.Version
+			pkg["is_sync_awaiting"] = packageItem.IsSyncAwaiting
+			pkg["is_sync_completed"] = packageItem.IsSyncCompleted
+			pkg["is_sync_failed"] = packageItem.IsSyncFailed
+			pkg["is_sync_in_progress"] = packageItem.IsSyncInProgress
+			pkg["is_sync_in_flight"] = packageItem.IsSyncInFlight
+			pkgs[i] = pkg
+		}
+
+		return pkgs
+	}
+	return make([]interface{}, 0)
+}
+
+func dataSourcePackages() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePackagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:         schema.TypeString,
+				Description:  "The repository of the package",
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"namespace": {
+				Type:         schema.TypeString,
+				Description:  "The namespace of the package",
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"package": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"repository": {
+							Type:        schema.TypeString,
+							Description: "The repository of the package",
+							Computed:    true,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Description: "The namespace of the package",
+							Computed:    true,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "A descriptive name for the package.",
+							Computed:    true,
+						},
+						"slug": {
+							Type:        schema.TypeString,
+							Description: "The slug identifies the package in URIs.",
+							Computed:    true,
+						},
+						"slug_perm": {
+							Type: schema.TypeString,
+							Description: "The slug_perm immutably identifies the package. " +
+								"It will never change once a package has been created.",
+							Computed: true,
+						},
+						"format": {
+							Type:        schema.TypeString,
+							Description: "The format of the package",
+							Computed:    true,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Description: "The version of the package",
+							Computed:    true,
+						},
+						"is_sync_awaiting": {
+							Type:        schema.TypeBool,
+							Description: "Is the package awaiting synchronisation",
+							Computed:    true,
+						},
+						"is_sync_completed": {
+							Type:        schema.TypeBool,
+							Description: "Has the package synchronisation completed",
+							Computed:    true,
+						},
+						"is_sync_failed": {
+							Type:        schema.TypeBool,
+							Description: "Has the package synchronisation failed",
+							Computed:    true,
+						},
+						"is_sync_in_progress": {
+							Type:        schema.TypeBool,
+							Description: "Is the package synchronisation currently in-progress",
+							Computed:    true,
+						},
+						"is_sync_in_flight": {
+							Type:        schema.TypeBool,
+							Description: "Is the package synchronisation currently in-flight",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/cloudsmith/data_source_repository.go
+++ b/cloudsmith/data_source_repository.go
@@ -1,0 +1,134 @@
+package cloudsmith
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+	namespace := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+
+	repository, _, err := pc.APIClient.ReposApi.ReposRead(pc.Auth, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	d.Set("cdn_url", repository.CdnUrl)
+	d.Set("created_at", repository.CreatedAt)
+	d.Set("deleted_at", repository.DeletedAt)
+	d.Set("description", repository.Description)
+	d.Set("index_files", repository.IndexFiles)
+	d.Set("namespace_url", repository.NamespaceUrl)
+	d.Set("repository_type", repository.RepositoryTypeStr)
+	d.Set("self_html_url", repository.SelfHtmlUrl)
+	d.Set("self_url", repository.SelfUrl)
+	d.Set("slug", repository.Slug)
+	d.Set("slug_perm", repository.SlugPerm)
+	d.Set("storage_region", repository.StorageRegion)
+
+	d.SetId(fmt.Sprintf("%s_%s", namespace, name))
+
+	return nil
+
+}
+
+//nolint:funlen
+func dataSourceRepository() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRepositoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"cdn_url": {
+				Type:        schema.TypeString,
+				Description: "Base URL from which packages and other artifacts are downloaded.",
+				Computed:    true,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Description: "ISO 8601 timestamp at which the repository was created.",
+				Computed:    true,
+			},
+			"deleted_at": {
+				Type: schema.TypeString,
+				Description: "ISO 8601 timestamp at which the repository was deleted " +
+					"(repositories are soft deleted temporarily to allow cancelling).",
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Description:  "A description of the repository's purpose/contents.",
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"index_files": {
+				Type: schema.TypeBool,
+				Description: "If checked, files contained in packages will be indexed, which increase the " +
+					"synchronisation time required for packages. Note that it is recommended you keep this " +
+					"enabled unless the synchronisation time is significantly impacted.",
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "A descriptive name for the repository.",
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"namespace": {
+				Type:         schema.TypeString,
+				Description:  "Namespace to which this repository belongs.",
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"namespace_url": {
+				Type:        schema.TypeString,
+				Description: "API endpoint where data about this namespace can be retrieved.",
+				Computed:    true,
+			},
+			"repository_type": {
+				Type: schema.TypeString,
+				Description: "The repository type changes how it is accessed and billed. Private repositories " +
+					"can only be used on paid plans, but are visible only to you or authorised delegates. Public " +
+					"repositories are free to use on all plans and visible to all Cloudsmith users.",
+				Optional:     true,
+				Default:      "Private",
+				ValidateFunc: validation.StringInSlice([]string{"Private", "Public"}, false),
+			},
+			"self_html_url": {
+				Type:        schema.TypeString,
+				Description: "Website URL for this repository.",
+				Computed:    true,
+			},
+			"self_url": {
+				Type:        schema.TypeString,
+				Description: "API endpoint where data about this repository can be retrieved.",
+				Computed:    true,
+			},
+			"slug": {
+				Type:         schema.TypeString,
+				Description:  "The slug identifies the repository in URIs.",
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"slug_perm": {
+				Type: schema.TypeString,
+				Description: "The slug_perm immutably identifies the repository. " +
+					"It will never change once a repository has been created.",
+				Computed: true,
+			},
+			"storage_region": {
+				Type:         schema.TypeString,
+				Description:  "The Cloudsmith region in which package files are stored.",
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}

--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -29,6 +29,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"cloudsmith_namespace": dataSourceNamespace(),
+			"cloudsmith_packages":  dataSourcePackages(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudsmith_entitlement": resourceEntitlement(),

--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -28,8 +28,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"cloudsmith_namespace": dataSourceNamespace(),
-			"cloudsmith_packages":  dataSourcePackages(),
+			"cloudsmith_namespace":  dataSourceNamespace(),
+			"cloudsmith_packages":   dataSourcePackages(),
+			"cloudsmith_repository": dataSourceRepository(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudsmith_entitlement": resourceEntitlement(),

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/cloudsmith-io/cloudsmith-api-go v0.0.9
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
+	github.com/mattn/go-isatty v0.0.5 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/antihax/optional v1.0.0
-	github.com/cloudsmith-io/cloudsmith-api-go v0.0.9
+	github.com/cloudsmith-io/cloudsmith-api-go v0.0.13
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
 	github.com/mattn/go-isatty v0.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXH
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.9 h1:LikZMtIfZ+db/3SOYwu398ZJekXKrO+XQy9M/vihS0w=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.9/go.mod h1:82pqUMCvbolBe4O770GLsOFQ/AFGxmiSx1pL2hoEldU=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.13 h1:tKbZxIE0wRvabobgH8cKbPNluuGxyEwaP2BQVZ5qzTM=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.13/go.mod h1:M3yPWZd89v81XdHMiIR2se5FRnrHLM+mKvgvzpRkMs8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,7 @@ golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This datasource can be used to retrieve packages from Cloudsmith for a given Namespace and Repository. I have implemented a paging handler as I was surprised by the behaviour of the PackageList API call. I have also implemented filters and their usage is encouraged, to avoid repeated calls/large datasets. 

The version of the Cloudsmith Go API library is out of date. The provider did not work as the API now returns an integer for the Package.Stage value. The library version that was in-use expected a string.