### PR TITLE
Added Repository and Packages Data Source Docs + Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,14 @@ data "cloudsmith_namespace" "my_namespace" {
 }
 
 data "cloudsmith_repository" "my_repository" {
-  namespace = data.cloudsmith_namespace.my_namespace.slug
-  name      = "My Repository"
+  namespace  = data.cloudsmith_namespace.my_namespace.slug
+  identifier = "my-repository"
 }
 
-data "cloudsmith_packages" "my_packages" {
+data "cloudsmith_package_list" "my_packages" {
   namespace     = data.cloudsmith_repository.my_repository.namespace
-  repository    = data.cloudsmith_repository.my_repository.slug
-  package_group = "my-package"
-  filters       = ["format:docker"]
+  repository    = data.cloudsmith_repository.my_repository.slug_perm
+  filters       = ["format:docker", "name:^my-package"]
 }
 
 output "packages" {

--- a/cloudsmith/data_source_repository.go
+++ b/cloudsmith/data_source_repository.go
@@ -10,7 +10,7 @@ import (
 func dataSourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
 	namespace := d.Get("namespace").(string)
-	name := d.Get("name").(string)
+	name := d.Get("identifier").(string)
 
 	repository, _, err := pc.APIClient.ReposApi.ReposRead(pc.Auth, namespace, name)
 	if err != nil {
@@ -59,9 +59,14 @@ func dataSourceRepository() *schema.Resource {
 				Computed: true,
 			},
 			"description": {
+				Type:        schema.TypeString,
+				Description: "A description of the repository's purpose/contents.",
+				Computed:    true,
+			},
+			"identifier": {
 				Type:         schema.TypeString,
-				Description:  "A description of the repository's purpose/contents.",
-				Optional:     true,
+				Description:  "The identifier for this repository.",
+				Required:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"index_files": {
@@ -69,14 +74,7 @@ func dataSourceRepository() *schema.Resource {
 				Description: "If checked, files contained in packages will be indexed, which increase the " +
 					"synchronisation time required for packages. Note that it is recommended you keep this " +
 					"enabled unless the synchronisation time is significantly impacted.",
-				Optional: true,
 				Computed: true,
-			},
-			"name": {
-				Type:         schema.TypeString,
-				Description:  "A descriptive name for the repository.",
-				Required:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"namespace": {
 				Type:         schema.TypeString,
@@ -94,9 +92,7 @@ func dataSourceRepository() *schema.Resource {
 				Description: "The repository type changes how it is accessed and billed. Private repositories " +
 					"can only be used on paid plans, but are visible only to you or authorised delegates. Public " +
 					"repositories are free to use on all plans and visible to all Cloudsmith users.",
-				Optional:     true,
-				Default:      "Private",
-				ValidateFunc: validation.StringInSlice([]string{"Private", "Public"}, false),
+				Computed: true,
 			},
 			"self_html_url": {
 				Type:        schema.TypeString,
@@ -109,11 +105,9 @@ func dataSourceRepository() *schema.Resource {
 				Computed:    true,
 			},
 			"slug": {
-				Type:         schema.TypeString,
-				Description:  "The slug identifies the repository in URIs.",
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:        schema.TypeString,
+				Description: "The slug identifies the repository in URIs.",
+				Computed:    true,
 			},
 			"slug_perm": {
 				Type: schema.TypeString,
@@ -122,12 +116,9 @@ func dataSourceRepository() *schema.Resource {
 				Computed: true,
 			},
 			"storage_region": {
-				Type:         schema.TypeString,
-				Description:  "The Cloudsmith region in which package files are stored.",
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:        schema.TypeString,
+				Description: "The Cloudsmith region in which package files are stored.",
+				Computed:    true,
 			},
 		},
 	}

--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -28,9 +28,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"cloudsmith_namespace":  dataSourceNamespace(),
-			"cloudsmith_packages":   dataSourcePackages(),
-			"cloudsmith_repository": dataSourceRepository(),
+			"cloudsmith_namespace":    dataSourceNamespace(),
+			"cloudsmith_package_list": dataSourcePackageList(),
+			"cloudsmith_repository":   dataSourceRepository(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudsmith_entitlement": resourceEntitlement(),

--- a/docs/data-sources/package_list.md
+++ b/docs/data-sources/package_list.md
@@ -1,0 +1,48 @@
+# Package List Data Source
+
+The `package_list` data source allows for retrieval of a list of packages within a given repository.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_namespace" "my_namespace" {
+    slug = "my-namespace"
+}
+
+data "cloudsmith_repository" "my_repository" {
+    namespace  = data.cloudsmith_namespace.my_namespace.slug_perm
+    identifier = "my-repository"
+}
+
+data "cloudsmith_package_list" "my_packages" {
+    namespace  = data.cloudsmith_repository.my_repository.namespace
+    repository = data.cloudsmith_repository.my_repository.slug_perm
+
+    package_group = "my-package"
+    filters       = ["format:docker"]
+}
+
+output "packages" {
+    value = formatlist("%s-%s", data.cloudsmith_package_list.my_packages.packages.*.name, data.cloudsmith_package_List.my_packages.*.version)
+}
+```
+
+## Argument Reference
+
+* `namespace` - (Required) Namespace to which the packages belong.
+* `repository` - (Required) Repository `slug_perm` to which the packages belong.
+* `filters` - (Optional) A list of Cloudsmith search filters (e.g `format:docker`, `name:^foo`).
+* `most_recent` - (Optional) When `true`, only the most recent package resolved will be returned.
+
+## Attribute Reference
+
+All of the argument attributes are also exported as result attributes.
+
+The following attribute is additionally exported:
+
+* `packages` - A list of `package` entries as discovered by the data source.
+

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -1,0 +1,44 @@
+# Repository Data Source
+
+The `repository` data source allows for access to repository properties.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_namespace" "my_namespace" {
+    slug = "my-namespace"
+}
+
+data "cloudsmith_repository" "my_repository" {
+    namespace  = data.cloudsmith_namespace.my_namespace.slug_perm
+    identifier = "my-repository"
+}
+```
+
+## Argument Reference
+
+* `namespace` - (Required) Namespace to which the repository belongs.
+* `identifier` - (Required) An identifier used to resolve this repository. This can be the repository `slug`, or `slug_perm`.
+
+## Attribute Reference
+
+All of the argument attributes are also exported as result attributes.
+
+Additionally, the following attributes are also exported:
+
+* `cdn_url` - Base URL from which packages and other artifacts are downloaded.
+* `created_at` - ISO 8601 timestamp at which the repository was created.
+* `deleted_at` - ISO 8601 timestamp at which the repository was deleted.
+* `description` - A description of the repository's purpose/contents.
+* `index_files` - When `true`, package indexing is enabled for this repository.
+* `namespace_url` - API endpoint to where data about this namespace can be retrieved.
+* `repository_type` - A string describing the type of repository (Private, Public, Open-Source)
+* `self_html_url` - The Cloudsmith web URL for this repository.
+* `self_url` - The Cloudsmith API endpoint for this repository.
+* `slug` - The slug identifies the repository in URIs.
+* `slug_perm` - The internal immutable identifier for this repository.
+* `storage_region` - The Cloudsmith region in which package files are stored.


### PR DESCRIPTION
## What Changed

* Added documentation to the `Repository` and `PackageList` data sources.
* Made `cloudsmith_repository` consume `identifier` rather than `name`
* Fixes for data source schema integrity (inputs vs outputs)
* Renamed `cloudsmith_packages` to `cloudsmith_package_list`
* Removed `package_group` from the packages data source, this can be specified via `filters` more explicitly.