### PR TITLE
Move terraform.ResourceProvider usage up to `main.go`

### DIFF
--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -6,11 +6,10 @@ import (
 	"runtime"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-// Provider returns a terraform.ResourceProvider.
-func Provider() terraform.ResourceProvider {
+// Provider returns a schema.Provider.
+func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {

--- a/main.go
+++ b/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"github.com/cloudsmith-io/terraform-provider-cloudsmith/cloudsmith"
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: cloudsmith.Provider,
+		ProviderFunc: func() terraform.ResourceProvider { return cloudsmith.Provider() },
 	})
 }


### PR DESCRIPTION
This is a small refactoring, done in service of porting this provider to [Pulumi][pulumi] using their [Pulumi/Terraform Bridge][tfbridge]. The bridge introspects the Terraform provider's Go code to extract the schema of the provider as an input to a codegen process. It is coded in terms of `schema.Provider`, rather than `terraform.ResourceProvider`, though.

[pulumi]: https://pulumi.com
[tfbridge]: https://github.com/pulumi/pulumi-terraform-bridge