### PR TITLE
fix: mark entitlement token as sensitive

### DIFF
--- a/cloudsmith/resource_entitlement.go
+++ b/cloudsmith/resource_entitlement.go
@@ -235,6 +235,7 @@ func resourceEntitlement() *schema.Resource {
 				Description:  "The literal value of the token to be created.",
 				Optional:     true,
 				Computed:     true,
+				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},


### PR DESCRIPTION
Mark `cloudsmith_entitlement.token` as sensitive so that it doesn't appear in logs or other CLI output.
