### PR TITLE
feat: add cloudsmith_team resource

### DIFF
--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -37,6 +37,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudsmith_entitlement": resourceEntitlement(),
 			"cloudsmith_repository":  resourceRepository(),
+			"cloudsmith_team":        resourceTeam(),
 			"cloudsmith_webhook":     resourceWebhook(),
 		},
 	}

--- a/cloudsmith/resource_team.go
+++ b/cloudsmith/resource_team.go
@@ -1,0 +1,189 @@
+package cloudsmith
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceTeamCreate(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsTeamsCreate(pc.Auth, org)
+	req = req.Data(cloudsmith.OrganizationTeamRequest{
+		Description: optionalString(d, "description"),
+		Name:        requiredString(d, "name"),
+		Slug:        optionalString(d, "slug"),
+		Visibility:  optionalString(d, "visibility"),
+	})
+
+	team, _, err := pc.APIClient.OrgsApi.OrgsTeamsCreateExecute(req)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(team.GetSlugPerm())
+
+	checkerFunc := func() error {
+		req := pc.APIClient.OrgsApi.OrgsTeamsRead(pc.Auth, org, d.Id())
+		if _, resp, err := pc.APIClient.OrgsApi.OrgsTeamsReadExecute(req); err != nil {
+			if is404(resp) {
+				return errKeepWaiting
+			}
+			return err
+		}
+		return nil
+	}
+	if err := waiter(checkerFunc, defaultCreationTimeout, defaultCreationInterval); err != nil {
+		return fmt.Errorf("error waiting for team (%s) to be created: %w", d.Id(), err)
+	}
+
+	return resourceTeamRead(d, m)
+}
+
+func resourceTeamRead(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsTeamsRead(pc.Auth, org, d.Id())
+	team, resp, err := pc.APIClient.OrgsApi.OrgsTeamsReadExecute(req)
+	if err != nil {
+		if is404(resp) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("description", team.GetDescription())
+	d.Set("name", team.GetName())
+	d.Set("slug", team.GetSlug())
+	d.Set("slug_perm", team.GetSlugPerm())
+	d.Set("visibility", team.GetVisibility())
+
+	// organization is not returned from the team read endpoint, so we can use
+	// the value stored in resource state. We rely on ForceNew to ensure if it
+	// changes a new resource is created.
+	d.Set("organization", org)
+
+	return nil
+}
+
+func resourceTeamUpdate(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsTeamsPartialUpdate(pc.Auth, org, d.Id())
+	req = req.Data(cloudsmith.OrganizationTeamRequestPatch{
+		Description: optionalString(d, "description"),
+		Name:        optionalString(d, "name"),
+		Slug:        optionalString(d, "slug"),
+		Visibility:  optionalString(d, "visibility"),
+	})
+	team, _, err := pc.APIClient.OrgsApi.OrgsTeamsPartialUpdateExecute(req)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(team.GetSlugPerm())
+
+	checkerFunc := func() error {
+		// this is somewhat of a hack until we have a better way to poll for a
+		// team being updated (changes incoming on the API side)
+		time.Sleep(time.Second * 5)
+		return nil
+	}
+	if err := waiter(checkerFunc, defaultUpdateTimeout, defaultUpdateInterval); err != nil {
+		return fmt.Errorf("error waiting for team (%s) to be updated: %w", d.Id(), err)
+	}
+
+	return resourceTeamRead(d, m)
+}
+
+func resourceTeamDelete(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsTeamsDelete(pc.Auth, org, d.Id())
+	_, err := pc.APIClient.OrgsApi.OrgsTeamsDeleteExecute(req)
+	if err != nil {
+		return err
+	}
+
+	checkerFunc := func() error {
+		req := pc.APIClient.OrgsApi.OrgsTeamsRead(pc.Auth, org, d.Id())
+		if _, resp, err := pc.APIClient.OrgsApi.OrgsTeamsReadExecute(req); err != nil {
+			if is404(resp) {
+				return nil
+			}
+			return err
+		}
+		return errKeepWaiting
+	}
+	if err := waiter(checkerFunc, defaultDeletionTimeout, defaultDeletionInterval); err != nil {
+		return fmt.Errorf("error waiting for team (%s) to be deleted: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+//nolint:funlen
+func resourceTeam() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTeamCreate,
+		Read:   resourceTeamRead,
+		Update: resourceTeamUpdate,
+		Delete: resourceTeamDelete,
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:         schema.TypeString,
+				Description:  "A description of the team's purpose.",
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "A descriptive name for the team.",
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"organization": {
+				Type:         schema.TypeString,
+				Description:  "Organization to which this team belongs.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"slug": {
+				Type:         schema.TypeString,
+				Description:  "The slug identifies the team in URIs.",
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"slug_perm": {
+				Type: schema.TypeString,
+				Description: "The slug_perm immutably identifies the team. " +
+					"It will never change once a team has been created.",
+				Computed: true,
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "Controls if the team is visible or hidden from non-members.",
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Visible", "Hidden"}, false),
+			},
+		},
+	}
+}

--- a/cloudsmith/resource_team_test.go
+++ b/cloudsmith/resource_team_test.go
@@ -1,0 +1,146 @@
+//nolint:testpackage
+package cloudsmith
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// TestAccTeam_basic spins up a team with all default options,
+// verifies it exists and checks the name is set correctly. Then it changes the
+// name, and verifies it's been set correctly before tearing down the resource
+// and verifying deletion.
+//
+// NOTE: It is not necessary to check properties that have been explicitly set
+// as Terraform performs a drift/plan check after every step anyway. Only
+// computed properties need explicitly checked.
+func TestAccTeam_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccTeamCheckDestroy("cloudsmith_team.test"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccTeamCheckExists("cloudsmith_team.test"),
+					// check a sample of computed properties have been set correctly
+					resource.TestCheckResourceAttr("cloudsmith_team.test", "description", ""),
+					resource.TestCheckResourceAttr("cloudsmith_team.test", "slug", "tf-test-team"),
+					resource.TestCheckResourceAttrSet("cloudsmith_team.test", "slug_perm"),
+					resource.TestCheckResourceAttr("cloudsmith_team.test", "visibility", "Visible"),
+				),
+			},
+			{
+				Config: testAccTeamConfigBasicUpdateName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccTeamCheckExists("cloudsmith_team.test"),
+				),
+			},
+			{
+				Config:      testAccTeamConfigBasicInvalidProp,
+				ExpectError: regexp.MustCompile("expected visibility to be one of"),
+			},
+			{
+				Config: testAccTeamConfigBasicUpdateProps,
+				Check: resource.ComposeTestCheckFunc(
+					testAccTeamCheckExists("cloudsmith_team.test"),
+				),
+			},
+		},
+	})
+}
+
+//nolint:goerr113
+func testAccTeamCheckDestroy(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+
+		req := pc.APIClient.OrgsApi.OrgsTeamsRead(pc.Auth, os.Getenv("CLOUDSMITH_NAMESPACE"), resourceState.Primary.ID)
+		_, resp, err := pc.APIClient.OrgsApi.OrgsTeamsReadExecute(req)
+		if err != nil && !is404(resp) {
+			return fmt.Errorf("unable to verify team deletion: %w", err)
+		} else if is200(resp) {
+			return fmt.Errorf("unable to verify team deletion: still exists: %s/%s", os.Getenv("CLOUDSMITH_NAMESPACE"), resourceState.Primary.ID)
+		}
+		defer resp.Body.Close()
+
+		return nil
+	}
+}
+
+//nolint:goerr113
+func testAccTeamCheckExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+
+		req := pc.APIClient.OrgsApi.OrgsTeamsRead(pc.Auth, os.Getenv("CLOUDSMITH_NAMESPACE"), resourceState.Primary.ID)
+		_, resp, err := pc.APIClient.OrgsApi.OrgsTeamsReadExecute(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		return nil
+	}
+}
+
+var testAccTeamConfigBasic = fmt.Sprintf(`
+resource "cloudsmith_team" "test" {
+	name         = "TF Test Team"
+	organization = "%s"
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccTeamConfigBasicUpdateName = fmt.Sprintf(`
+resource "cloudsmith_team" "test" {
+	name         = "TF Test Team Updated"
+	organization = "%s"
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccTeamConfigBasicInvalidProp = fmt.Sprintf(`
+resource "cloudsmith_team" "test" {
+	name         = "TF Test Team Updated"
+	organization = "%s"
+
+	visibility = "Nope"
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccTeamConfigBasicUpdateProps = fmt.Sprintf(`
+resource "cloudsmith_team" "test" {
+	name         = "TF Test Team Updated"
+	organization = "%s"
+
+	description = "I am the team, coo coo ca choo"
+	slug        = "my-very-imaginative-slug"
+	visibility  = "Visible"
+
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -1,0 +1,38 @@
+# Team Resource
+
+The teams resource allows creation and management of teams within a Cloudsmith organization.
+
+See [help.cloudsmith.io](https://help.cloudsmith.io/docs/teams) for full team documentation.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_organization" "my_org" {
+    slug = "my-org"
+}
+
+resource "cloudsmith_team" "my_team" {
+    organization = data.cloudsmith_organization.my_org.slug_perm
+    name         = "My Team"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) A description of the team's purpose.
+* `name` - (Required) A descriptive name for the team.
+* `organization` - (Required) Organization to which this team belongs.
+* `slug` - (Optional) The slug identifies the team in URIs.
+* `visibility` - (Optional) Controls if the team is visible or hidden from non-members.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `slug_perm` - The slug_perm immutably identifies the team. It will never change once a team has been created.


### PR DESCRIPTION
This PR adds a new `cloudsmith_team` resource to allow managing teams for an organization.
