### PR TITLE
feat: add service resource

### DIFF
--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -37,6 +37,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudsmith_entitlement": resourceEntitlement(),
 			"cloudsmith_repository":  resourceRepository(),
+			"cloudsmith_service":     resourceService(),
 			"cloudsmith_team":        resourceTeam(),
 			"cloudsmith_webhook":     resourceWebhook(),
 		},

--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -1,0 +1,285 @@
+package cloudsmith
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/samber/lo"
+)
+
+var (
+	roles = []string{
+		"Manager",
+		"Member",
+	}
+)
+
+// expandTeams extracts team assignments from TF state as a *schema.Set and
+// converts to a slice of strings we can use when interacting with the
+// Cloudsmith API.
+func expandTeams(d *schema.ResourceData) []cloudsmith.ServiceTeams {
+	set := d.Get("team").(*schema.Set)
+
+	teams := lo.Map(set.List(), func(x interface{}, index int) cloudsmith.ServiceTeams {
+		m := x.(map[string]interface{})
+		t := cloudsmith.ServiceTeams{}
+		role := m["role"].(string)
+		if role != "" {
+			t.SetRole(role)
+		}
+		t.SetSlug(m["slug"].(string))
+
+		return t
+	})
+
+	if len(teams) == 0 {
+		return nil
+	}
+
+	return teams
+}
+
+// flattenTeams takes a slice of cloudsmith.ServiceTeams as returned by the
+// Cloudsmith API and converts to a *schema.Set that can be stored in TF state.
+func flattenTeams(teams []cloudsmith.ServiceTeams) *schema.Set {
+	teamSchema := resourceService().Schema["team"].Elem.(*schema.Resource)
+	set := schema.NewSet(schema.HashResource(teamSchema), []interface{}{})
+	for _, team := range teams {
+		set.Add(map[string]interface{}{
+			"role": team.GetRole(),
+			"slug": team.GetSlug(),
+		})
+	}
+	return set
+}
+
+func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsServicesCreate(pc.Auth, org)
+	req = req.Data(cloudsmith.ServiceRequest{
+		Description: optionalString(d, "description"),
+		Name:        requiredString(d, "name"),
+		Role:        optionalString(d, "role"),
+		Teams:       expandTeams(d),
+	})
+
+	service, _, err := pc.APIClient.OrgsApi.OrgsServicesCreateExecute(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(service.GetSlug())
+
+	// normally we'd read this value back on read, but it's only returned over
+	// the API when the resource is created, otherwise it's redacted.
+	// Unfortunately this means that if the user needs to rotate the service's
+	// API key then the only way to do it and have it reflected properly in
+	// Terraform is to taint the whole resource and let Terraform recreate it.
+	d.Set("key", service.GetKey())
+
+	checkerFunc := func() error {
+		req := pc.APIClient.OrgsApi.OrgsServicesRead(pc.Auth, org, d.Id())
+		if _, resp, err := pc.APIClient.OrgsApi.OrgsServicesReadExecute(req); err != nil {
+			if is404(resp) {
+				return errKeepWaiting
+			}
+			return err
+		}
+		return nil
+	}
+	if err := waiter(checkerFunc, defaultCreationTimeout, defaultCreationInterval); err != nil {
+		return diag.Errorf("error waiting for service (%s) to be created: %s", d.Id(), err)
+	}
+
+	return resourceServiceRead(ctx, d, m)
+}
+
+func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsServicesRead(pc.Auth, org, d.Id())
+
+	service, resp, err := pc.APIClient.OrgsApi.OrgsServicesReadExecute(req)
+	if err != nil {
+		if is404(resp) {
+			d.SetId("")
+			return nil
+		}
+
+		return diag.FromErr(err)
+	}
+
+	d.Set("description", service.GetDescription())
+	d.Set("name", service.GetName())
+	d.Set("role", service.GetRole())
+	d.Set("slug", service.GetSlug())
+	d.Set("team", flattenTeams(service.GetTeams()))
+
+	// since we don't get the full API key when reading a service back from the
+	// API, we need to check if it has changed and if so warn the user that
+	// they'll need to recreate the resource if they want to pull the new key
+	// into Terraform. This can be accomplished by tainting.
+	var diags diag.Diagnostics
+	existingLastFour := requiredString(d, "key")[len(requiredString(d, "key"))-4:]
+	newLastFour := service.GetKey()[len(service.GetKey())-4:]
+	if existingLastFour != newLastFour {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "API key has changed",
+			Detail: "API key for this service has changed outside of Terraform. If this " +
+				"key is used within Terraform the resource must be tainted or otherwise " +
+				"recreated to retrieve the new value.",
+			AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
+		})
+	}
+
+	// organization is not returned from the service read endpoint, so we can
+	// use the value stored in resource state. We rely on ForceNew to ensure if
+	// it changes a new resource is created.
+	d.Set("organization", org)
+
+	return diags
+}
+
+func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsServicesPartialUpdate(pc.Auth, org, d.Id())
+	req = req.Data(cloudsmith.ServiceRequestPatch{
+		Description: optionalString(d, "description"),
+		Name:        optionalString(d, "name"),
+		Role:        optionalString(d, "role"),
+		Teams:       expandTeams(d),
+	})
+
+	service, _, err := pc.APIClient.OrgsApi.OrgsServicesPartialUpdateExecute(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(service.GetSlug())
+
+	checkerFunc := func() error {
+		// this is somewhat of a hack until we have a better way to poll for a
+		// service being updated (changes incoming on the API side)
+		time.Sleep(time.Second * 5)
+		return nil
+	}
+	if err := waiter(checkerFunc, defaultUpdateTimeout, defaultUpdateInterval); err != nil {
+		return diag.Errorf("error waiting for service (%s) to be updated: %s", d.Id(), err)
+	}
+
+	return resourceServiceRead(ctx, d, m)
+}
+
+func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+
+	org := requiredString(d, "organization")
+
+	req := pc.APIClient.OrgsApi.OrgsServicesDelete(pc.Auth, org, d.Id())
+	_, err := pc.APIClient.OrgsApi.OrgsServicesDeleteExecute(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	checkerFunc := func() error {
+		req := pc.APIClient.OrgsApi.OrgsServicesRead(pc.Auth, org, d.Id())
+		if _, resp, err := pc.APIClient.OrgsApi.OrgsServicesReadExecute(req); err != nil {
+			if is404(resp) {
+				return nil
+			}
+			return err
+		}
+		return errKeepWaiting
+	}
+	if err := waiter(checkerFunc, defaultDeletionTimeout, defaultDeletionInterval); err != nil {
+		return diag.Errorf("error waiting for service (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+//nolint:funlen
+func resourceService() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServiceCreate,
+		ReadContext:   resourceServiceRead,
+		UpdateContext: resourceServiceUpdate,
+		DeleteContext: resourceServiceDelete,
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:         schema.TypeString,
+				Description:  "A description of the service's purpose.",
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Description: "The service's API key.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "A descriptive name for the service.",
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"organization": {
+				Type:         schema.TypeString,
+				Description:  "Organization to which this service belongs.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"role": {
+				Type:         schema.TypeString,
+				Description:  "The service's role in the organization.",
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(roles, false),
+			},
+			"slug": {
+				Type:        schema.TypeString,
+				Description: "The slug identifies the service in URIs.",
+				Computed:    true,
+			},
+			"team": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role": {
+							Type:         schema.TypeString,
+							Description:  "The service's role in the organization.",
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice(roles, false),
+						},
+						"slug": {
+							Type:         schema.TypeString,
+							Description:  "The team the service should be added to.",
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}

--- a/cloudsmith/resource_service_test.go
+++ b/cloudsmith/resource_service_test.go
@@ -1,0 +1,139 @@
+//nolint:testpackage
+package cloudsmith
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// TestAccService_basic spins up a service with all default options, verifies it
+// exists and checks the attributes. Then it performs some updates and verifies
+// them before tearing down the resources and verifying deletion.
+//
+// NOTE: It is not necessary to check properties that have been explicitly set
+// as Terraform performs a drift/plan check after every step anyway. Only
+// computed properties need explicitly checked.
+func TestAccService_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccServiceCheckDestroy("cloudsmith_service.test"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccServiceCheckExists("cloudsmith_service.test"),
+					// check a sample of computed properties have been set correctly
+					resource.TestCheckResourceAttr("cloudsmith_service.test", "description", ""),
+					resource.TestCheckResourceAttr("cloudsmith_service.test", "slug", "tf-test-service"),
+					resource.TestCheckResourceAttrSet("cloudsmith_service.test", "key"),
+					resource.TestCheckResourceAttr("cloudsmith_service.test", "role", "Member"),
+					resource.TestCheckNoResourceAttr("cloudsmith_service.test", "team.#"),
+				),
+			},
+			{
+				Config: testAccServiceConfigBasicUpdateName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccServiceCheckExists("cloudsmith_service.test"),
+				),
+			},
+			{
+				Config: testAccServiceConfigBasicAddToTeam,
+				Check: resource.ComposeTestCheckFunc(
+					testAccServiceCheckExists("cloudsmith_service.test"),
+					resource.TestCheckResourceAttrSet("cloudsmith_service.test", "team.#"),
+					resource.TestCheckResourceAttr("cloudsmith_service.test", "team.0.role", "Manager"),
+				),
+			},
+		},
+	})
+}
+
+//nolint:goerr113
+func testAccServiceCheckDestroy(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+
+		req := pc.APIClient.OrgsApi.OrgsServicesRead(pc.Auth, os.Getenv("CLOUDSMITH_NAMESPACE"), resourceState.Primary.ID)
+		_, resp, err := pc.APIClient.OrgsApi.OrgsServicesReadExecute(req)
+		if err != nil && !is404(resp) {
+			return fmt.Errorf("unable to verify service deletion: %w", err)
+		} else if is200(resp) {
+			return fmt.Errorf("unable to verify service deletion: still exists: %s/%s", os.Getenv("CLOUDSMITH_NAMESPACE"), resourceState.Primary.ID)
+		}
+		defer resp.Body.Close()
+
+		return nil
+	}
+}
+
+//nolint:goerr113
+func testAccServiceCheckExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+
+		req := pc.APIClient.OrgsApi.OrgsServicesRead(pc.Auth, os.Getenv("CLOUDSMITH_NAMESPACE"), resourceState.Primary.ID)
+		_, resp, err := pc.APIClient.OrgsApi.OrgsServicesReadExecute(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		return nil
+	}
+}
+
+var testAccServiceConfigBasic = fmt.Sprintf(`
+resource "cloudsmith_service" "test" {
+	name         = "TF Test Service"
+	organization = "%s"
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccServiceConfigBasicUpdateName = fmt.Sprintf(`
+resource "cloudsmith_service" "test" {
+	name         = "TF Test Service Updated"
+	organization = "%s"
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccServiceConfigBasicAddToTeam = fmt.Sprintf(`
+resource "cloudsmith_team" "test" {
+	name         = "TF Test Team"
+	organization = "%s"
+}
+
+resource "cloudsmith_service" "test" {
+	name         = "TF Test Service"
+	organization = "%s"
+	role         = "Manager"
+
+	team {
+		slug = cloudsmith_team.test.slug
+	}
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"), os.Getenv("CLOUDSMITH_NAMESPACE"))

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -1,0 +1,50 @@
+# Service Resource
+
+The service resource allows the creation and management of services for a given Cloudsmith organization. Services allow users to create API keys that can be used for machine-to-machine or other programmatic access without requiring a real user account.
+
+See [help.cloudsmith.io](https://help.cloudsmith.io/docs/service-accounts) for full service documentation.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_organization" "my_org" {
+    slug = "my-org"
+}
+
+resource "cloudsmith_team" "my_team" {
+    organization = data.cloudsmith_organization.my_org.slug_perm
+    name         = "My Team"
+}
+
+resource "cloudsmith_service" "my_service" {
+	name         = "My Service"
+	organization = data.cloudsmith_organization.my_org.slug_perm
+
+	team {
+		slug = cloudsmith_team.my_team.slug
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) A description of the service's purpose.
+* `name` - (Required) A descriptive name for the service.
+* `organization` - (Required) Organization to which this service belongs.
+* `role` - (Optional) The service's role in the organization. If defined, must be one of `Member` or `Manager`.
+* `team` - (Optional) Variable number of blocks containing team assignments for this service.
+	* `role` - (Optional) The service's role in the team. If defined, must be one of `Member` or `Manager`.
+    * `slug` - (Required) The team the service should be added to.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `key` - The service's API key.
+* `slug` - The slug identifies the service in URIs or where a username is required.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -8,16 +8,16 @@ See [help.cloudsmith.io](https://help.cloudsmith.io/docs/service-accounts) for f
 
 ```hcl
 provider "cloudsmith" {
-    api_key = "my-api-key"
+	api_key = "my-api-key"
 }
 
 data "cloudsmith_organization" "my_org" {
-    slug = "my-org"
+	slug = "my-org"
 }
 
 resource "cloudsmith_team" "my_team" {
-    organization = data.cloudsmith_organization.my_org.slug_perm
-    name         = "My Team"
+	organization = data.cloudsmith_organization.my_org.slug_perm
+	name         = "My Team"
 }
 
 resource "cloudsmith_service" "my_service" {
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `role` - (Optional) The service's role in the organization. If defined, must be one of `Member` or `Manager`.
 * `team` - (Optional) Variable number of blocks containing team assignments for this service.
 	* `role` - (Optional) The service's role in the team. If defined, must be one of `Member` or `Manager`.
-    * `slug` - (Required) The team the service should be added to.
+	* `slug` - (Required) The team the service should be added to.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/cloudsmith-io/cloudsmith-api-go v0.0.19
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/samber/lo v1.36.0
 )
@@ -18,7 +19,6 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.6 // indirect


### PR DESCRIPTION
This PR adds a new `cloudsmith_service` resource to allow managing services (service accounts/bots) for an organization.
