### PR TITLE
fix: deprecate cloudsmith_namespace data source

### DIFF
--- a/cloudsmith/data_source_namespace.go
+++ b/cloudsmith/data_source_namespace.go
@@ -27,6 +27,8 @@ func dataSourceNamespaceRead(d *schema.ResourceData, m interface{}) error {
 
 func dataSourceNamespace() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "use cloudsmith_organization data source instead",
+
 		Read: dataSourceNamespaceRead,
 
 		Schema: map[string]*schema.Schema{

--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -1,5 +1,7 @@
 # Namespace Data Source
 
+!> **WARNING:** This data source is deprecated and will be removed in future. Use `cloudsmith_organization` instead.
+
 The `namespace` data source allows fetching of metadata about a given Cloudsmith namespace. The fetched data can be used to resolve permanent identifiers from a namespace's user-facing name. These identifiers can then be passed to other resources to allow more consistent identification as user-facing names can change.
 
 ## Example Usage

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -9,19 +9,19 @@ provider "cloudsmith" {
     api_key = "my-api-key"
 }
 
-data "cloudsmith_namespace" "my_namespace" {
-    slug = "my-namespace"
+data "cloudsmith_organization" "my_organization" {
+    slug = "my-organization"
 }
 
 data "cloudsmith_repository" "my_repository" {
-    namespace  = data.cloudsmith_namespace.my_namespace.slug_perm
+    namespace  = data.cloudsmith_organization.my_organization.slug_perm
     identifier = "my-repository"
 }
 ```
 
 ## Argument Reference
 
-* `namespace` - (Required) Namespace to which the repository belongs.
+* `namespace` - (Required) Namespace (or organization) to which the repository belongs.
 * `identifier` - (Required) An identifier used to resolve this repository. This can be the repository `slug`, or `slug_perm`.
 
 ## Attribute Reference

--- a/docs/resources/entitlement.md
+++ b/docs/resources/entitlement.md
@@ -11,14 +11,14 @@ provider "cloudsmith" {
     api_key = "my-api-key"
 }
 
-data "cloudsmith_namespace" "my_namespace" {
-    slug = "my-namespace"
+data "cloudsmith_organization" "my_organization" {
+    slug = "my-organization"
 }
 
 resource "cloudsmith_repository" "my_repository" {
     description = "A certifiably-awesome private package repository"
     name        = "My Repository"
-    namespace   = "${data.cloudsmith_namespace.my_namespace.slug_perm}"
+    namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
     slug        = "my-repository"
 }
 
@@ -39,7 +39,7 @@ resource "cloudsmith_entitlement" "my_entitlement" {
 * `limit_package_query` - (Optional) The package-based search query to apply to restrict downloads to. This uses the same syntax as the standard search used for repositories, and also supports boolean logic operators such as OR/AND/NOT and parentheses for grouping. This will still allow access to non-package files, such as metadata.
 * `limit_path_query` - (Optional) The path-based search query to apply to restrict downloads to. This supports boolean logic operators such as OR/AND/NOT and parentheses for grouping. The path evaluated does not include the domain name, the namespace, the entitlement code used, the package format, etc. and it always starts with a forward slash.
 * `name` - (Required) A descriptive name for the entitlement.
-* `namespace` - (Required) Namespace to which this entitlement belongs.
+* `namespace` - (Required) Namespace (or organization) to which this entitlement belongs.
 * `repository` - (Required) Repository to which this entitlement belongs.
 * `token` - (Optional) The literal value of the token to be created.
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -11,14 +11,14 @@ provider "cloudsmith" {
     api_key = "my-api-key"
 }
 
-data "cloudsmith_namespace" "my_namespace" {
-    slug = "my-namespace"
+data "cloudsmith_organization" "my_organization" {
+    slug = "my-organization"
 }
 
 resource "cloudsmith_repository" "my_repository" {
     description = "A certifiably-awesome private package repository"
     name        = "My Repository"
-    namespace   = "${data.cloudsmith_namespace.my_namespace.slug_perm}"
+    namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
     slug        = "my-repository"
 }
 ```
@@ -38,7 +38,7 @@ repository. This does not include collaborators, but applies to any member of th
 * `move_own` - (Optional) If checked, users can move any of their own packages that they have uploaded, assuming that they still have write privilege for the repository. This takes precedence over privileges configured in the 'Access Controls' section of the repository, and any inherited from the org.
 * `move_packages` - (Optional) This defines the minimum level of privilege required for a user to move packages. Unless the package was uploaded by that user, in which the permission may be overridden by the user-specific move setting.
 * `name` - (Required) A descriptive name for the repository.
-* `namespace` - (Required) Namespace to which this repository belongs.
+* `namespace` - (Required) Namespace (or organization) to which this repository belongs.
 * `proxy_npmjs` - (Optional) If checked, Npm packages that are not in the repository when requested by clients will automatically be proxied from the public npmjs.org registry. If there is at least one version for a package, others will not be proxied.
 * `proxy_pypi` - (Optional) If checked, Python packages that are not in the repository when requested by clients will automatically be proxied from the public pypi.python.org registry. If there is at least one version for a package, others will not be proxied.
 * `raw_package_index_enabled` - (Optional) If checked, HTML and JSON indexes will be generated that list all available raw packages in the repository.

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -11,14 +11,14 @@ provider "cloudsmith" {
     api_key = "my-api-key"
 }
 
-data "cloudsmith_namespace" "my_namespace" {
-    slug = "my-namespace"
+data "cloudsmith_organization" "my_organization" {
+    slug = "my-organization"
 }
 
 resource "cloudsmith_repository" "my_repository" {
     description = "A certifiably-awesome private package repository"
     name        = "My Repository"
-    namespace   = "${data.cloudsmith_namespace.my_namespace.slug_perm}"
+    namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
     slug        = "my-repository"
 }
 
@@ -46,7 +46,7 @@ resource "cloudsmith_webhook" "my_webhook" {
 
 * `events` - (Required) List of events for which this webhook will be fired.
 * `is_active` - (Optional) If enabled, the webhook will trigger on subscribed events and send payloads to the configured target URL.
-* `namespace` - (Required) Namespace to which this webhook belongs.
+* `namespace` - (Required) Namespace (or organization) to which this webhook belongs.
 * `package_query` - (Optional) The package-based search query for webhooks to fire. This uses the same syntax as the standard search used for repositories, and also supports boolean logic operators such as OR/AND/NOT and parentheses for grouping. If a package does not match, the webhook will not fire.
 * `repository` - (Required) Repository to which this webhook belongs.
 * `request_body_format` - (Optional) The format of the payloads for webhook requests.


### PR DESCRIPTION
This PR deprecates the `cloudsmith_namespace` data source in favor of the newer `cloudsmith_organization` data source.

The existing resource will continue to work, but will be removed in future once `namespace` is fully removed from the cloudsmith API and website.
