### PR TITLE
feat: add cloudsmith_repository_privileges resource

### DIFF
--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -35,11 +35,12 @@ func Provider() *schema.Provider {
 			"cloudsmith_repository":   dataSourceRepository(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"cloudsmith_entitlement": resourceEntitlement(),
-			"cloudsmith_repository":  resourceRepository(),
-			"cloudsmith_service":     resourceService(),
-			"cloudsmith_team":        resourceTeam(),
-			"cloudsmith_webhook":     resourceWebhook(),
+			"cloudsmith_entitlement":           resourceEntitlement(),
+			"cloudsmith_repository":            resourceRepository(),
+			"cloudsmith_repository_privileges": resourceRepositoryPrivileges(),
+			"cloudsmith_service":               resourceService(),
+			"cloudsmith_team":                  resourceTeam(),
+			"cloudsmith_webhook":               resourceWebhook(),
 		},
 	}
 

--- a/cloudsmith/resource_repository_privileges.go
+++ b/cloudsmith/resource_repository_privileges.go
@@ -1,0 +1,303 @@
+package cloudsmith
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/samber/lo"
+)
+
+var (
+	repositoryPrivileges = []string{
+		"Admin",
+		"Write",
+		"Read",
+	}
+)
+
+// expandRepositoryPrivilegeServices extracts "services" from TF state as a *schema.Set and converts to
+// a slice of structs we can use when interacting with the Cloudsmith API.
+func expandRepositoryPrivilegeServices(d *schema.ResourceData) []cloudsmith.RepositoryPrivilegeDict {
+	set := d.Get("service").(*schema.Set)
+
+	return lo.Map(set.List(), func(x interface{}, index int) cloudsmith.RepositoryPrivilegeDict {
+		m := x.(map[string]interface{})
+		p := cloudsmith.RepositoryPrivilegeDict{}
+		p.SetPrivilege(m["privilege"].(string))
+		p.SetService(m["slug"].(string))
+
+		return p
+	})
+}
+
+// expandRepositoryPrivilegeTeams extracts "teams" from TF state as a *schema.Set and converts to
+// a slice of structs we can use when interacting with the Cloudsmith API.
+func expandRepositoryPrivilegeTeams(d *schema.ResourceData) []cloudsmith.RepositoryPrivilegeDict {
+	set := d.Get("team").(*schema.Set)
+
+	return lo.Map(set.List(), func(x interface{}, index int) cloudsmith.RepositoryPrivilegeDict {
+		m := x.(map[string]interface{})
+		p := cloudsmith.RepositoryPrivilegeDict{}
+		p.SetPrivilege(m["privilege"].(string))
+		p.SetTeam(m["slug"].(string))
+
+		return p
+	})
+}
+
+// expandRepositoryPrivilegeUsers extracts "users" from TF state as a *schema.Set and converts to
+// a slice of structs we can use when interacting with the Cloudsmith API.
+func expandRepositoryPrivilegeUsers(d *schema.ResourceData) []cloudsmith.RepositoryPrivilegeDict {
+	set := d.Get("user").(*schema.Set)
+
+	return lo.Map(set.List(), func(x interface{}, index int) cloudsmith.RepositoryPrivilegeDict {
+		m := x.(map[string]interface{})
+		p := cloudsmith.RepositoryPrivilegeDict{}
+		p.SetPrivilege(m["privilege"].(string))
+		p.SetUser(m["slug"].(string))
+
+		return p
+	})
+}
+
+// flattenRepositoryPrivilegeServices takes a slice of
+// cloudsmith.RepositoryPrivilegeDict as returned by the Cloudsmith API and
+// converts to a *schema.Set that can be stored in TF state.
+func flattenRepositoryPrivilegeServices(privileges []cloudsmith.RepositoryPrivilegeDict) *schema.Set {
+	serviceSchema := resourceRepositoryPrivileges().Schema["service"].Elem.(*schema.Resource)
+	set := schema.NewSet(schema.HashResource(serviceSchema), []interface{}{})
+
+	hasService := func(p cloudsmith.RepositoryPrivilegeDict, index int) bool {
+		return p.HasService()
+	}
+
+	for _, privilege := range lo.Filter(privileges, hasService) {
+		set.Add(map[string]interface{}{
+			"privilege": privilege.GetPrivilege(),
+			"slug":      privilege.GetService(),
+		})
+	}
+	return set
+}
+
+// flattenRepositoryPrivilegeTeams takes a slice of
+// cloudsmith.RepositoryPrivilegeDict as returned by the Cloudsmith API and
+// converts to a *schema.Set that can be stored in TF state.
+func flattenRepositoryPrivilegeTeams(privileges []cloudsmith.RepositoryPrivilegeDict) *schema.Set {
+	teamSchema := resourceRepositoryPrivileges().Schema["team"].Elem.(*schema.Resource)
+	set := schema.NewSet(schema.HashResource(teamSchema), []interface{}{})
+
+	hasTeam := func(p cloudsmith.RepositoryPrivilegeDict, index int) bool {
+		return p.HasTeam()
+	}
+
+	for _, privilege := range lo.Filter(privileges, hasTeam) {
+		set.Add(map[string]interface{}{
+			"privilege": privilege.GetPrivilege(),
+			"slug":      privilege.GetTeam(),
+		})
+	}
+	return set
+}
+
+// flattenRepositoryPrivilegeUsers takes a slice of
+// cloudsmith.RepositoryPrivilegeDict as returned by the Cloudsmith API and
+// converts to a *schema.Set that can be stored in TF state.
+func flattenRepositoryPrivilegeUsers(privileges []cloudsmith.RepositoryPrivilegeDict) *schema.Set {
+	userSchema := resourceRepositoryPrivileges().Schema["user"].Elem.(*schema.Resource)
+	set := schema.NewSet(schema.HashResource(userSchema), []interface{}{})
+
+	hasUser := func(p cloudsmith.RepositoryPrivilegeDict, index int) bool {
+		return p.HasUser()
+	}
+
+	for _, privilege := range lo.Filter(privileges, hasUser) {
+		set.Add(map[string]interface{}{
+			"privilege": privilege.GetPrivilege(),
+			"slug":      privilege.GetUser(),
+		})
+	}
+	return set
+}
+
+func resourceRepositoryPrivilegesCreateUpdate(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	organization := requiredString(d, "organization")
+	repository := requiredString(d, "repository")
+
+	privileges := []cloudsmith.RepositoryPrivilegeDict{}
+	privileges = append(privileges, expandRepositoryPrivilegeServices(d)...)
+	privileges = append(privileges, expandRepositoryPrivilegeTeams(d)...)
+	privileges = append(privileges, expandRepositoryPrivilegeUsers(d)...)
+
+	req := pc.APIClient.ReposApi.ReposPrivilegesUpdate(pc.Auth, organization, repository)
+	req = req.Data(cloudsmith.RepositoryPrivilegeInputRequest{
+		Privileges: privileges,
+	})
+
+	_, err := pc.APIClient.ReposApi.ReposPrivilegesUpdateExecute(req)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", organization, repository))
+
+	checkerFunc := func() error {
+		// this is somewhat of a hack until we have a better way to poll for
+		// repository privileges being updated (changes incoming on the API side)
+		time.Sleep(time.Second * 5)
+		return nil
+	}
+	if err := waiter(checkerFunc, defaultUpdateTimeout, defaultUpdateInterval); err != nil {
+		return fmt.Errorf("error waiting for privileges (%s) to be updated: %w", d.Id(), err)
+	}
+
+	return resourceRepositoryPrivilegesRead(d, m)
+}
+
+func resourceRepositoryPrivilegesRead(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	organization := requiredString(d, "organization")
+	repository := requiredString(d, "repository")
+
+	req := pc.APIClient.ReposApi.ReposPrivilegesList(pc.Auth, organization, repository)
+
+	// TODO: add a proper loop here to ensure we always get all privs,
+	// regardless of how many are configured.
+	req = req.Page(1)
+	req = req.PageSize(1000)
+
+	privileges, resp, err := pc.APIClient.ReposApi.ReposPrivilegesListExecute(req)
+	if err != nil {
+		if is404(resp) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("service", flattenRepositoryPrivilegeServices(privileges.GetPrivileges()))
+	d.Set("team", flattenRepositoryPrivilegeTeams(privileges.GetPrivileges()))
+	d.Set("user", flattenRepositoryPrivilegeUsers(privileges.GetPrivileges()))
+
+	// namespace and repository are not returned from the privileges read
+	// endpoint, so we can use the values stored in resource state. We rely on
+	// ForceNew to ensure if either changes a new resource is created.
+	d.Set("organization", organization)
+	d.Set("repository", repository)
+
+	return nil
+}
+
+func resourceRepositoryPrivilegesDelete(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	organization := requiredString(d, "organization")
+	repository := requiredString(d, "repository")
+
+	req := pc.APIClient.ReposApi.ReposPrivilegesUpdate(pc.Auth, organization, repository)
+	req = req.Data(cloudsmith.RepositoryPrivilegeInputRequest{
+		Privileges: []cloudsmith.RepositoryPrivilegeDict{},
+	})
+
+	_, err := pc.APIClient.ReposApi.ReposPrivilegesUpdateExecute(req)
+	if err != nil {
+		return err
+	}
+
+	checkerFunc := func() error {
+		// this is somewhat of a hack until we have a better way to poll for
+		// repository privileges being deleted (changes incoming on the API side)
+		time.Sleep(time.Second * 5)
+		return nil
+	}
+	if err := waiter(checkerFunc, defaultUpdateTimeout, defaultUpdateInterval); err != nil {
+		return fmt.Errorf("error waiting for privileges (%s) to be deleted: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+//nolint:funlen
+func resourceRepositoryPrivileges() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRepositoryPrivilegesCreateUpdate,
+		Read:   resourceRepositoryPrivilegesRead,
+		Update: resourceRepositoryPrivilegesCreateUpdate,
+		Delete: resourceRepositoryPrivilegesDelete,
+
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:         schema.TypeString,
+				Description:  "Organization to which this repository belongs.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"repository": {
+				Type:         schema.TypeString,
+				Description:  "Repository to which these privileges belong.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"service": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"privilege": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(repositoryPrivileges, false),
+						},
+						"slug": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"team": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"privilege": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(repositoryPrivileges, false),
+						},
+						"slug": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"user": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"privilege": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(repositoryPrivileges, false),
+						},
+						"slug": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/cloudsmith/resource_repository_privileges_test.go
+++ b/cloudsmith/resource_repository_privileges_test.go
@@ -1,0 +1,180 @@
+//nolint:testpackage
+package cloudsmith
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccRepositoryPrivileges_basic spins up a repository with default options,
+// creates a service account and a couple of teams, assigning and modifying
+// their permissions before tearing down and verifying deletion.
+func TestAccRepositoryPrivileges_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccRepositoryCheckDestroy("cloudsmith_repository.test"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryPrivilegesConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudsmith_repository_privileges.test", "service.0.privilege", "Read"),
+				),
+			},
+			{
+				Config: testAccRepositoryPrivilegesConfigBasicUpdatePrivilege,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudsmith_repository_privileges.test", "service.0.privilege", "Write"),
+				),
+			},
+			{
+				Config: testAccRepositoryPrivilegesConfigBasicAddTeam,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudsmith_repository_privileges.test", "service.0.privilege", "Write"),
+					resource.TestCheckResourceAttr("cloudsmith_repository_privileges.test", "team.0.privilege", "Write"),
+				),
+			},
+			{
+				Config: testAccRepositoryPrivilegesConfigBasicAddAnotherTeam,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudsmith_repository_privileges.test", "service.0.privilege", "Write"),
+					resource.TestCheckTypeSetElemNestedAttrs("cloudsmith_repository_privileges.test", "team.*", map[string]string{
+						"privilege": "Write",
+						"slug":      "tf-test-team-privs-2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("cloudsmith_repository_privileges.test", "team.*", map[string]string{
+						"privilege": "Read",
+						"slug":      "tf-test-team-privs-1",
+					}),
+				),
+			},
+		},
+	})
+}
+
+var testAccRepositoryPrivilegesConfigBasic = fmt.Sprintf(`
+resource "cloudsmith_repository" "test" {
+	name      = "terraform-acc-test-privs"
+	namespace = "%s"
+}
+
+resource "cloudsmith_service" "test" {
+	name         = "TF Test Service Privs"
+	organization = cloudsmith_repository.test.namespace
+	role         = "Member"
+}
+
+resource "cloudsmith_repository_privileges" "test" {
+    organization = cloudsmith_repository.test.namespace
+    repository   = cloudsmith_repository.test.slug
+
+	service {
+		privilege = "Read"
+		slug      = cloudsmith_service.test.slug
+	}
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccRepositoryPrivilegesConfigBasicUpdatePrivilege = fmt.Sprintf(`
+resource "cloudsmith_repository" "test" {
+	name      = "terraform-acc-test-privs"
+	namespace = "%s"
+}
+
+resource "cloudsmith_service" "test" {
+	name         = "TF Test Service Privs"
+	organization = cloudsmith_repository.test.namespace
+	role         = "Member"
+}
+
+resource "cloudsmith_repository_privileges" "test" {
+    organization = cloudsmith_repository.test.namespace
+    repository   = cloudsmith_repository.test.slug
+
+	service {
+		privilege = "Write"
+		slug      = cloudsmith_service.test.slug
+	}
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccRepositoryPrivilegesConfigBasicAddTeam = fmt.Sprintf(`
+resource "cloudsmith_repository" "test" {
+	name      = "terraform-acc-test-privs"
+	namespace = "%s"
+}
+
+resource "cloudsmith_service" "test" {
+	name         = "TF Test Service Privs"
+	organization = cloudsmith_repository.test.namespace
+	role         = "Member"
+}
+
+resource "cloudsmith_team" "test_1" {
+	name         = "TF Test Team Privs 1"
+	organization = cloudsmith_repository.test.namespace
+}
+
+resource "cloudsmith_repository_privileges" "test" {
+    organization = cloudsmith_repository.test.namespace
+    repository   = cloudsmith_repository.test.slug
+
+	service {
+		privilege = "Write"
+		slug      = cloudsmith_service.test.slug
+	}
+
+	team {
+		privilege = "Write"
+		slug      = cloudsmith_team.test_1.slug
+	}
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
+
+var testAccRepositoryPrivilegesConfigBasicAddAnotherTeam = fmt.Sprintf(`
+resource "cloudsmith_repository" "test" {
+	name      = "terraform-acc-test-privs"
+	namespace = "%s"
+}
+
+resource "cloudsmith_service" "test" {
+	name         = "TF Test Service Privs"
+	organization = cloudsmith_repository.test.namespace
+	role         = "Member"
+}
+
+resource "cloudsmith_team" "test_1" {
+	name         = "TF Test Team Privs 1"
+	organization = cloudsmith_repository.test.namespace
+}
+
+resource "cloudsmith_team" "test_2" {
+	name         = "TF Test Team Privs 2"
+	organization = cloudsmith_repository.test.namespace
+}
+
+resource "cloudsmith_repository_privileges" "test" {
+    organization = cloudsmith_repository.test.namespace
+    repository   = cloudsmith_repository.test.slug
+
+	service {
+		privilege = "Write"
+		slug      = cloudsmith_service.test.slug
+	}
+
+	team {
+		privilege = "Write"
+		slug      = cloudsmith_team.test_2.slug
+	}
+
+	team {
+		privilege = "Read"
+		slug      = cloudsmith_team.test_1.slug
+	}
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))

--- a/cloudsmith/utils.go
+++ b/cloudsmith/utils.go
@@ -121,6 +121,12 @@ type waitFunc func() error
 // action. This is mostly useful for actions that change state and may not be
 // immediately reflected in the API for any reason.
 func waiter(checker waitFunc, timeout, interval time.Duration) error {
+	// the initial sleep here helps avoid issues with cross-region database
+	// replication. Most endpoints deal with this fine, but there are still a
+	// few edge cases that we need to fix in the APIs before we can safely
+	// remove this.
+	time.Sleep(interval)
+
 	for start := time.Now(); time.Since(start) < timeout; {
 		if err := checker(); err != nil {
 			if err == errKeepWaiting {

--- a/docs/resources/repository_privileges.md
+++ b/docs/resources/repository_privileges.md
@@ -20,7 +20,7 @@ data "cloudsmith_organization" "my_organization" {
 resource "cloudsmith_repository" "my_repository" {
     description = "A certifiably-awesome private package repository"
     name        = "My Repository"
-    namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
+    namespace   = data.cloudsmith_organization.my_organization.slug_perm
     slug        = "my-repository"
 }
 
@@ -40,8 +40,8 @@ resource "cloudsmith_service" "my_service" {
 }
 
 resource "cloudsmith_repository_privileges" "privs" {
-    organization = data.cloudsmith_organization.test.slug
-    repository   = cloudsmith_repository.test.slug
+    organization = data.cloudsmith_organization.my_organization.slug
+    repository   = cloudsmith_repository.my_repository.slug
 
 	service {
 		privilege = "Write"

--- a/docs/resources/repository_privileges.md
+++ b/docs/resources/repository_privileges.md
@@ -25,18 +25,18 @@ resource "cloudsmith_repository" "my_repository" {
 }
 
 resource "cloudsmith_team" "my_team" {
-	organization = data.cloudsmith_organization.my_org.slug_perm
+	organization = data.cloudsmith_organization.my_organization.slug_perm
 	name         = "My Team"
 }
 
 resource "cloudsmith_team" "my_other_team" {
-	organization = data.cloudsmith_organization.my_org.slug_perm
+	organization = data.cloudsmith_organization.my_organization.slug_perm
 	name         = "My Other Team"
 }
 
 resource "cloudsmith_service" "my_service" {
 	name         = "My Service"
-	organization = data.cloudsmith_organization.my_org.slug_perm
+	organization = data.cloudsmith_organization.my_organization.slug_perm
 }
 
 resource "cloudsmith_repository_privileges" "privs" {
@@ -45,7 +45,7 @@ resource "cloudsmith_repository_privileges" "privs" {
 
 	service {
 		privilege = "Write"
-		slug      = cloudsmith_service.test.slug
+		slug      = cloudsmith_service.my_service.slug
 	}
 
 	team {

--- a/docs/resources/repository_privileges.md
+++ b/docs/resources/repository_privileges.md
@@ -1,0 +1,82 @@
+# Respository Privileges Resource
+
+The repository privileges resource allows the management of privileges for a given Cloudsmith repository. Using this resource it is possible to assign users, teams, or service accounts to a repository, and define the appropriate permission level for each.
+
+Note that while users can be added to repositories in this manner, since Terraform does not (and cannot currently) manage those user accounts, you may encounter issues if the users change or are deleted outside of Terraform.
+
+See [help.cloudsmith.io](https://help.cloudsmith.io/docs/permissions#repository-permissions) for full permissions documentation.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_organization" "my_organization" {
+    slug = "my-organization"
+}
+
+resource "cloudsmith_repository" "my_repository" {
+    description = "A certifiably-awesome private package repository"
+    name        = "My Repository"
+    namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
+    slug        = "my-repository"
+}
+
+resource "cloudsmith_team" "my_team" {
+	organization = data.cloudsmith_organization.my_org.slug_perm
+	name         = "My Team"
+}
+
+resource "cloudsmith_team" "my_other_team" {
+	organization = data.cloudsmith_organization.my_org.slug_perm
+	name         = "My Other Team"
+}
+
+resource "cloudsmith_service" "my_service" {
+	name         = "My Service"
+	organization = data.cloudsmith_organization.my_org.slug_perm
+}
+
+resource "cloudsmith_repository_privileges" "privs" {
+    organization = data.cloudsmith_organization.test.slug
+    repository   = cloudsmith_repository.test.slug
+
+	service {
+		privilege = "Write"
+		slug      = cloudsmith_service.test.slug
+	}
+
+	team {
+		privilege = "Write"
+		slug      = cloudsmith_team.my_team.slug
+	}
+
+	team {
+		privilege = "Read"
+		slug      = cloudsmith_team.my_other_team.slug
+	}
+
+    user {
+        privilege = "Read"
+        slug      = "some-user-slug"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) Organization to which this repository belongs.
+* `repository` - (Required) Repository to which these privileges apply.
+* `service` - (Optional) Variable number of blocks containing service accounts that should have repository privileges.
+	* `privilege` - (Required) The service's privilege level in the repository. Must be one of `Admin`, `Write`, or `Read`.
+	* `slug` - (Required) The slug/identifier of the service.
+* `team` - (Optional) Variable number of blocks containing teams that should have repository privileges.
+	* `privilege` - (Required) The team's privilege level in the repository. Must be one of `Admin`, `Write`, or `Read`.
+	* `slug` - (Required) The slug/identifier of the team.
+* `user` - (Optional) Variable number of blocks containing users that should have repository privileges.
+	* `privilege` - (Required) The user's privilege level in the repository. Must be one of `Admin`, `Write`, or `Read`.
+	* `slug` - (Required) The slug/identifier of the user.


### PR DESCRIPTION
This PR adds a new `cloudsmith_repository_privileges` resource to allow managing privileges/permissions (service accounts, teams, and users) for a repository.
