### PR TITLE
feat: add repo geo/ip rules resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .terraform/
 main.tf
 terraform.tfstate

--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -35,12 +35,13 @@ func Provider() *schema.Provider {
 			"cloudsmith_repository":   dataSourceRepository(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"cloudsmith_entitlement":           resourceEntitlement(),
-			"cloudsmith_repository":            resourceRepository(),
-			"cloudsmith_repository_privileges": resourceRepositoryPrivileges(),
-			"cloudsmith_service":               resourceService(),
-			"cloudsmith_team":                  resourceTeam(),
-			"cloudsmith_webhook":               resourceWebhook(),
+			"cloudsmith_entitlement":             resourceEntitlement(),
+			"cloudsmith_repository":              resourceRepository(),
+			"cloudsmith_repository_geo_ip_rules": resourceRepositoryGeoIpRules(),
+			"cloudsmith_repository_privileges":   resourceRepositoryPrivileges(),
+			"cloudsmith_service":                 resourceService(),
+			"cloudsmith_team":                    resourceTeam(),
+			"cloudsmith_webhook":                 resourceWebhook(),
 		},
 	}
 

--- a/cloudsmith/resource_repository_geo_ip_rules.go
+++ b/cloudsmith/resource_repository_geo_ip_rules.go
@@ -132,7 +132,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			CidrAllow: {
 				Type:        schema.TypeSet,
 				Description: "The list of IP Addresses for which to allow access, expressed in CIDR notation.",
-				Required:    true,
+				Optional:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringIsNotEmpty,
@@ -141,7 +141,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			CidrDeny: {
 				Type:        schema.TypeSet,
 				Description: "The list of IP Addresses for which to deny access, expressed in CIDR notation.",
-				Required:    true,
+				Optional:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringIsNotEmpty,
@@ -150,7 +150,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			CountryCodeAllow: {
 				Type:        schema.TypeSet,
 				Description: "The list of countries for which to allow access, expressed in ISO 3166-1 country codes.",
-				Required:    true,
+				Optional:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringIsNotEmpty,
@@ -159,7 +159,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			CountryCodeDeny: {
 				Type:        schema.TypeSet,
 				Description: "The list of countries for which to deny access, expressed in ISO 3166-1 country codes.",
-				Required:    true,
+				Optional:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringIsNotEmpty,

--- a/cloudsmith/resource_repository_geo_ip_rules.go
+++ b/cloudsmith/resource_repository_geo_ip_rules.go
@@ -1,0 +1,184 @@
+package cloudsmith
+
+import (
+	"fmt"
+	"github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const Namespace string = "namespace"
+const Repository string = "repository"
+const CidrAllow string = "cidr_allow"
+const CidrDeny string = "cidr_deny"
+const CountryCodeAllow string = "country_code_allow"
+const CountryCodeDeny string = "country_code_deny"
+
+func resourceRepositoryGeoIpRulesCreate(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	namespace := requiredString(d, Namespace)
+	repository := requiredString(d, Repository)
+
+	// Ensure that Geo/IP rules are enabled for the Repository
+	req := pc.APIClient.ReposApi.ReposGeoipEnable(pc.Auth, namespace, repository)
+	_, err := pc.APIClient.ReposApi.ReposGeoipEnableExecute(req)
+	if err != nil {
+		return err
+	}
+
+	// The actual "create" is just the same as "update" for this resource.
+	return resourceRepositoryGeoIpRulesUpdate(d, m)
+}
+
+func resourceRepositoryGeoIpRulesRead(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	namespace := requiredString(d, Namespace)
+	repository := requiredString(d, Repository)
+
+	req := pc.APIClient.ReposApi.ReposGeoipRead(pc.Auth, namespace, repository)
+
+	geoIpRules, resp, err := pc.APIClient.ReposApi.ReposGeoipReadExecute(req)
+	if err != nil {
+		if is404(resp) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	cidr := geoIpRules.GetCidr()
+	countryCode := geoIpRules.GetCountryCode()
+
+	_ = d.Set(CidrAllow, flattenStrings(cidr.GetAllow()))
+	_ = d.Set(CidrDeny, flattenStrings(cidr.GetDeny()))
+	_ = d.Set(CountryCodeAllow, flattenStrings(countryCode.GetAllow()))
+	_ = d.Set(CountryCodeDeny, flattenStrings(countryCode.GetDeny()))
+
+	// namespace and repository are not returned from the read
+	// endpoint, so we can use the values stored in resource state. We rely on
+	// ForceNew to ensure if either changes a new resource is created.
+	_ = d.Set(Namespace, namespace)
+	_ = d.Set(Repository, repository)
+
+	return nil
+}
+
+func resourceRepositoryGeoIpRulesUpdate(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	namespace := requiredString(d, Namespace)
+	repository := requiredString(d, Repository)
+
+	req := pc.APIClient.ReposApi.ReposGeoipUpdate(pc.Auth, namespace, repository)
+	req = req.Data(cloudsmith.ReposGeoipRead200Response{
+		CountryCode: &cloudsmith.ReposGeoipRead200ResponseCountryCode{
+			Allow: expandStrings(d, CountryCodeAllow),
+			Deny:  expandStrings(d, CountryCodeDeny),
+		},
+		Cidr: &cloudsmith.ReposGeoipRead200ResponseCountryCode{
+			Allow: expandStrings(d, CidrAllow),
+			Deny:  expandStrings(d, CidrDeny),
+		},
+	})
+
+	_, err := pc.APIClient.ReposApi.ReposGeoipUpdateExecute(req)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s_%s_geo_ip_rules", namespace, repository))
+
+	return resourceRepositoryGeoIpRulesRead(d, m)
+}
+
+func resourceRepositoryGeoIpRulesDelete(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	namespace := requiredString(d, "namespace")
+	repository := requiredString(d, "repository")
+
+	// There isn't a DELETE endpoint, so just update the rules to be empty.
+	req := pc.APIClient.ReposApi.ReposGeoipUpdate(pc.Auth, namespace, repository)
+	req = req.Data(cloudsmith.ReposGeoipRead200Response{
+		CountryCode: &cloudsmith.ReposGeoipRead200ResponseCountryCode{
+			Allow: []string{},
+			Deny:  []string{},
+		},
+		Cidr: &cloudsmith.ReposGeoipRead200ResponseCountryCode{
+			Allow: []string{},
+			Deny:  []string{},
+		},
+	})
+	_, err := pc.APIClient.ReposApi.ReposGeoipUpdateExecute(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//nolint:funlen
+func resourceRepositoryGeoIpRules() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRepositoryGeoIpRulesCreate,
+		Read:   resourceRepositoryGeoIpRulesRead,
+		Update: resourceRepositoryGeoIpRulesUpdate,
+		Delete: resourceRepositoryGeoIpRulesDelete,
+
+		Schema: map[string]*schema.Schema{
+			CidrAllow: {
+				Type:        schema.TypeSet,
+				Description: "The list of IP Addresses and/or CIDR masks for which to allow access.",
+				Required:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+			CidrDeny: {
+				Type:        schema.TypeSet,
+				Description: "The list of IP Addresses and/or CIDR masks for which to deny access.",
+				Required:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+			CountryCodeAllow: {
+				Type:        schema.TypeSet,
+				Description: "The list of countries for which to allow access, using ISO 3166-1 country codes.",
+				Required:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+			CountryCodeDeny: {
+				Type:        schema.TypeSet,
+				Description: "The list of countries for which to deny access, using ISO 3166-1 country codes.",
+				Required:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+			Namespace: {
+				Type:         schema.TypeString,
+				Description:  "Namespace to which these Geo/IP rules belong.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			Repository: {
+				Type:         schema.TypeString,
+				Description:  "Repository to which these Geo/IP rules belong.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}

--- a/cloudsmith/resource_repository_geo_ip_rules.go
+++ b/cloudsmith/resource_repository_geo_ip_rules.go
@@ -131,7 +131,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			CidrAllow: {
 				Type:        schema.TypeSet,
-				Description: "The list of IP Addresses and/or CIDR masks for which to allow access.",
+				Description: "The list of IP Addresses for which to allow access, expressed in CIDR notation.",
 				Required:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -140,7 +140,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			},
 			CidrDeny: {
 				Type:        schema.TypeSet,
-				Description: "The list of IP Addresses and/or CIDR masks for which to deny access.",
+				Description: "The list of IP Addresses for which to deny access, expressed in CIDR notation.",
 				Required:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -149,7 +149,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			},
 			CountryCodeAllow: {
 				Type:        schema.TypeSet,
-				Description: "The list of countries for which to allow access, using ISO 3166-1 country codes.",
+				Description: "The list of countries for which to allow access, expressed in ISO 3166-1 country codes.",
 				Required:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -158,7 +158,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			},
 			CountryCodeDeny: {
 				Type:        schema.TypeSet,
-				Description: "The list of countries for which to deny access, using ISO 3166-1 country codes.",
+				Description: "The list of countries for which to deny access, expressed in ISO 3166-1 country codes.",
 				Required:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -167,7 +167,7 @@ func resourceRepositoryGeoIpRules() *schema.Resource {
 			},
 			Namespace: {
 				Type:         schema.TypeString,
-				Description:  "Namespace to which these Geo/IP rules belong.",
+				Description:  "Organization to which the Repository belongs.",
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,

--- a/cloudsmith/resource_repository_geo_ip_rules_test.go
+++ b/cloudsmith/resource_repository_geo_ip_rules_test.go
@@ -1,0 +1,153 @@
+//nolint:testpackage
+package cloudsmith
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const ResourceName string = "cloudsmith_repository_geo_ip_rules.test"
+const InitialCidrAllow string = "255.255.255.255/32"
+const UpdatedCidrAllow string = "1.1.1.1/32"
+const InitialCidrDeny string = "10.0.0.0/24"
+const UpdatedCidrDeny string = "6cc2:ab98:2143:7e6e:8827:e81a:1527:9645/128"
+const InitialCountryCodeAllow string = "BV"
+const UpdatedCountryCodeAllow string = "FO"
+const InitialCountryCodeDeny string = "CX"
+const UpdatedCountryCodeDeny string = "CK"
+const configTemplate string = `
+resource "cloudsmith_repository" "test" {
+	name      = "terraform-acc-test-repository-geo-ip-rules"
+	namespace = "%s"
+}
+
+resource "cloudsmith_repository_geo_ip_rules" "test" {
+    namespace          = "${resource.cloudsmith_repository.test.namespace}"
+    repository         = "${resource.cloudsmith_repository.test.slug_perm}"
+    cidr_allow         = ["%s"]
+    cidr_deny          = ["%s"]
+    country_code_allow = ["%s"]
+    country_code_deny  = ["%s"]
+}
+`
+
+var namespace = os.Getenv("CLOUDSMITH_NAMESPACE")
+var testAccRepositoryGeoIpRulesConfigCreate = fmt.Sprintf(configTemplate, namespace, InitialCidrAllow, InitialCidrDeny, InitialCountryCodeAllow, InitialCountryCodeDeny)
+var testAccRepositoryGeoIpRulesConfigUpdate = fmt.Sprintf(configTemplate, namespace, UpdatedCidrAllow, UpdatedCidrDeny, UpdatedCountryCodeAllow, UpdatedCountryCodeDeny)
+
+// TestAccRepositoryGeoIpRules_basic spins up a repository with all default options,
+// creates a set of geo/ip rules for the repository and verifies they exist. Then it
+// changes the geo/ip rules and verifies they've been set correctly before tearing down the
+// resources and verifying deletion.
+func TestAccRepositoryGeoIpRules_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccRepositoryGeoIpRulesCheckDestroy(ResourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryGeoIpRulesConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccRepositoryGeoIpRulesCheckExists(ResourceName, InitialCidrAllow, InitialCidrDeny, InitialCountryCodeAllow, InitialCountryCodeDeny),
+				),
+			},
+			{
+				Config: testAccRepositoryGeoIpRulesConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccRepositoryGeoIpRulesCheckExists(ResourceName, UpdatedCidrAllow, UpdatedCidrDeny, UpdatedCountryCodeAllow, UpdatedCountryCodeDeny),
+				),
+			},
+		},
+	})
+}
+
+//nolint:goerr113
+func testAccRepositoryGeoIpRulesCheckDestroy(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+
+		repository := resourceState.Primary.Attributes["repository"]
+
+		req := pc.APIClient.ReposApi.ReposGeoipRead(pc.Auth, namespace, repository)
+		_, resp, err := pc.APIClient.ReposApi.ReposGeoipReadExecute(req)
+		if err != nil && !is404(resp) {
+			return fmt.Errorf("unable to verify geo/ip rules deletion: %w", err)
+		} else if is200(resp) {
+			return fmt.Errorf("unable to verify geo/ip rules deletion: still exists: %s/%s", namespace, repository)
+		}
+		defer resp.Body.Close()
+
+		rreq := pc.APIClient.ReposApi.ReposRead(pc.Auth, namespace, repository)
+		_, resp, err = pc.APIClient.ReposApi.ReposReadExecute(rreq)
+		if err != nil && !is404(resp) {
+			return fmt.Errorf("unable to verify repository deletion: %w", err)
+		} else if is200(resp) {
+			return fmt.Errorf("unable to verify repository deletion: still exists: %s/%s", namespace, repository)
+		}
+		defer resp.Body.Close()
+
+		return nil
+	}
+}
+
+//nolint:goerr113
+func testAccRepositoryGeoIpRulesCheckExists(resourceName string, expectedCidrAllow string, expectedCidrDeny string, expectedCountryCodeAllow string, expectedCountryCodeDeny string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+
+		repository := resourceState.Primary.Attributes["repository"]
+
+		req := pc.APIClient.ReposApi.ReposGeoipRead(pc.Auth, namespace, repository)
+		geoIpRules, resp, err := pc.APIClient.ReposApi.ReposGeoipReadExecute(req)
+		if err != nil {
+			return fmt.Errorf("unable to verify Geo/IP rules existence: %w", err)
+		}
+		defer resp.Body.Close()
+
+		cidr := geoIpRules.GetCidr()
+
+		if !contains(cidr.GetAllow(), expectedCidrAllow) {
+			return fmt.Errorf("expected cidr_allow not found in rules")
+		}
+
+		if !contains(cidr.GetDeny(), expectedCidrDeny) {
+			return fmt.Errorf("expected cidr_deny not found in rules")
+		}
+
+		countryCode := geoIpRules.GetCountryCode()
+
+		if !contains(countryCode.GetAllow(), expectedCountryCodeAllow) {
+			return fmt.Errorf("expected country_code_allow not found in rules")
+		}
+
+		if !contains(countryCode.GetDeny(), expectedCountryCodeDeny) {
+			return fmt.Errorf("expected country_code_deny not found in rules")
+		}
+
+		return nil
+	}
+}

--- a/docs/resources/repository_geo_ip_rules.md
+++ b/docs/resources/repository_geo_ip_rules.md
@@ -49,9 +49,9 @@ resource "cloudsmith_repository_geo_ip_rules" "my_rules" {
 
 The following arguments are supported:
 
-* `namespace` - (Required) Organization to which this repository belongs.
-* `repository` - (Required) Repository to which these privileges apply.
-* `cidr_allow` - (Required) The list of IP addresses/ranges for which to allow access to the Repository.
-* `cidr_deny` - (Required) The list of IP addresses/ranges for which to deny access to the Repository.
-* `country_code_allow` - (Required) The list of countries for which to allow access to the Repository.
-* `country_code_deny` - (Required) The list of countries for which to deny access to the Repository.
+* `namespace` - (Required) Organization to which the Repository belongs.
+* `repository` - (Required) Repository to which these Geo/IP rules apply.
+* `cidr_allow` - (Required) The list of IP Addresses for which to allow access to the Repository, expressed in CIDR notation.
+* `cidr_deny` - (Required) The list of IP Addresses for which to deny access to the Repository, expressed in CIDR notation.
+* `country_code_allow` - (Required) The list of countries for which to allow access to the Repository, expressed in ISO 3166-1 country codes.
+* `country_code_deny` - (Required) The list of countries for which to deny access to the Repository, expressed in ISO 3166-1 country codes.

--- a/docs/resources/repository_geo_ip_rules.md
+++ b/docs/resources/repository_geo_ip_rules.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `namespace` - (Required) Organization to which the Repository belongs.
 * `repository` - (Required) Repository to which these Geo/IP rules apply.
-* `cidr_allow` - (Required) The list of IP Addresses for which to allow access to the Repository, expressed in CIDR notation.
-* `cidr_deny` - (Required) The list of IP Addresses for which to deny access to the Repository, expressed in CIDR notation.
-* `country_code_allow` - (Required) The list of countries for which to allow access to the Repository, expressed in ISO 3166-1 country codes.
-* `country_code_deny` - (Required) The list of countries for which to deny access to the Repository, expressed in ISO 3166-1 country codes.
+* `cidr_allow` - (Optional) The list of IP Addresses for which to allow access to the Repository, expressed in CIDR notation.
+* `cidr_deny` - (Optional) The list of IP Addresses for which to deny access to the Repository, expressed in CIDR notation.
+* `country_code_allow` - (Optional) The list of countries for which to allow access to the Repository, expressed in ISO 3166-1 country codes.
+* `country_code_deny` - (Optional) The list of countries for which to deny access to the Repository, expressed in ISO 3166-1 country codes.

--- a/docs/resources/repository_geo_ip_rules.md
+++ b/docs/resources/repository_geo_ip_rules.md
@@ -1,0 +1,57 @@
+# Respository Geo/IP Rules Resource
+
+The repository geo/ip rules resource allows the management of geo/ip rules for a given Cloudsmith repository. Using this resource it is possible to allow and/or deny access to a repository using CIDR notation, two-character ISO 3166-1 country codes or a combination thereof.
+
+See [help.cloudsmith.io](https://help.cloudsmith.io/docs/geoip-restriction) for full geo/ip rules documentation.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+    api_key = "my-api-key"
+}
+
+data "cloudsmith_organization" "my_organization" {
+    slug = "my-organization"
+}
+
+resource "cloudsmith_repository" "my_repository" {
+    description = "A certifiably-awesome private package repository"
+    name        = "My Repository"
+    namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
+    slug        = "my-repository"
+}
+
+resource "cloudsmith_repository_geo_ip_rules" "my_rules" {
+    namespace          = "${data.cloudsmith_organization.my_organization.slug_perm}"
+    repository         = "${resource.cloudsmith_repository.my_repository.slug_perm}"
+    cidr_allow         = [
+      "10.0.0.0/24",
+      "6cc2:ab98:2143:7e6e:8827:e81a:1527:9645/128",
+      "140.59.25.1/32",
+    ]
+    cidr_deny          = [
+      "83.154.136.12/32",
+      "203.0.0.0/10",
+    ]
+    country_code_allow = [
+      "ST",
+      "CM",
+    ]
+    country_code_deny  = [
+      "CA",
+      "WF",
+    ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Required) Organization to which this repository belongs.
+* `repository` - (Required) Repository to which these privileges apply.
+* `cidr_allow` - (Required) The list of IP addresses/ranges for which to allow access to the Repository.
+* `cidr_deny` - (Required) The list of IP addresses/ranges for which to deny access to the Repository.
+* `country_code_allow` - (Required) The list of countries for which to allow access to the Repository.
+* `country_code_deny` - (Required) The list of countries for which to deny access to the Repository.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsmith-io/terraform-provider-cloudsmith
 go 1.19
 
 require (
-	github.com/cloudsmith-io/cloudsmith-api-go v0.0.19
+	github.com/cloudsmith-io/cloudsmith-api-go v0.0.21
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/samber/lo v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.19 h1:NMwlRyMBsw/NK7EnyIim6Q2iQAP2xEodTe04Bva5G8Q=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.19/go.mod h1:XgzmIrQLx3aBku6exjIA9cBe1Tc0hHXWnZbwYakKnOI=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.21 h1:zniNdp3Ay4tRMlPd8Bpbc1mPcBhi8YIHnz8Nf8IoVpE=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.21/go.mod h1:gy13YfI9EfKcgy4M1soCymUTr1cv3Udwcj2KkJNr1fk=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Adds a new `cloudsmith_repository_geo_ip_rules` resource to allow managing Geo/IP restrictions for a repository.