### PR TITLE
Add Importer attribute

### DIFF
--- a/cloudsmith/resource_entitlement.go
+++ b/cloudsmith/resource_entitlement.go
@@ -249,5 +249,9 @@ func resourceEntitlement() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_entitlement.go
+++ b/cloudsmith/resource_entitlement.go
@@ -249,9 +249,5 @@ func resourceEntitlement() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
 	}
 }

--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -591,5 +591,9 @@ func resourceRepository() *schema.Resource {
 				Default:     true,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -281,5 +281,9 @@ func resourceService() *schema.Resource {
 				ForceNew: true,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_team.go
+++ b/cloudsmith/resource_team.go
@@ -185,5 +185,9 @@ func resourceTeam() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"Visible", "Hidden"}, false),
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_webhook.go
+++ b/cloudsmith/resource_webhook.go
@@ -450,5 +450,9 @@ func resourceWebhook() *schema.Resource {
 				Computed: true,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -109,3 +109,11 @@ repository. This does not include collaborators, but applies to any member of th
 * `use_vulnerability_scanning` - If checked, vulnerability scanning will be enabled for all supported packages within this repository.
 * `user_entitlements_enabled` - If checked, users can use and manage their own user-specific entitlement token for the repository (if private). Otherwise, user-specific entitlements are disabled for all users.
 * `view_statistics` - This defines the minimum level of privilege required for a user to view repository statistics, to include entitlement-based usage, if applicable. If a user does not have the permission, they won't be able to view any statistics, either via the UI, API or CLI.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_repository.my_repository my-repository-slug
+```

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -48,3 +48,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `key` - The service's API key.
 * `slug` - The slug identifies the service in URIs or where a username is required.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_service.my_service my-service-slug
+```

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -36,3 +36,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `slug_perm` - The slug_perm immutably identifies the team. It will never change once a team has been created.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_team.my_team my-team-slug
+```

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -69,3 +69,11 @@ resource "cloudsmith_webhook" "my_webhook" {
 * `slug_perm` - The slug_perm immutably identifies the webhook. It will never change once a webhook has been created.
 * `updated_at` - ISO 8601 timestamp at which the webhook was updated.
 * `updated_by` - The user/account that updated the webhook.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_webhook.my_webhook my-webhook-slug
+```


### PR DESCRIPTION
Add `terraform import` support for `entitlement`, `repository`, `service`, `team`, and `webhook` resources.

Fixes #34 