### PR TITLE
feat: add ability to import all resources

### DIFF
--- a/cloudsmith/resource_entitlement.go
+++ b/cloudsmith/resource_entitlement.go
@@ -1,13 +1,33 @@
 package cloudsmith
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+func importEntitlement(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.Split(d.Id(), ".")
+	if len(idParts) != 3 {
+		return nil, fmt.Errorf(
+			"invalid import ID, must be of the form <organization_slug>.<repository_slug>.<entitlement_slug>, got: %s", d.Id(),
+		)
+	}
+
+	tflog.Error(ctx, "ohno")
+	tflog.Error(ctx, d.Id())
+
+	d.Set("namespace", idParts[0])
+	d.Set("repository", idParts[1])
+	d.SetId(idParts[2])
+	return []*schema.ResourceData{d}, nil
+}
 
 func resourceEntitlementCreate(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
@@ -167,6 +187,10 @@ func resourceEntitlement() *schema.Resource {
 		Read:   resourceEntitlementRead,
 		Update: resourceEntitlementUpdate,
 		Delete: resourceEntitlementDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: importEntitlement,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"is_active": {

--- a/cloudsmith/resource_entitlement.go
+++ b/cloudsmith/resource_entitlement.go
@@ -249,5 +249,9 @@ func resourceEntitlement() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_entitlement.go
+++ b/cloudsmith/resource_entitlement.go
@@ -249,9 +249,5 @@ func resourceEntitlement() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
 	}
 }

--- a/cloudsmith/resource_entitlement.go
+++ b/cloudsmith/resource_entitlement.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -19,9 +18,6 @@ func importEntitlement(ctx context.Context, d *schema.ResourceData, m interface{
 			"invalid import ID, must be of the form <organization_slug>.<repository_slug>.<entitlement_slug>, got: %s", d.Id(),
 		)
 	}
-
-	tflog.Error(ctx, "ohno")
-	tflog.Error(ctx, d.Id())
 
 	d.Set("namespace", idParts[0])
 	d.Set("repository", idParts[1])

--- a/cloudsmith/resource_entitlement_test.go
+++ b/cloudsmith/resource_entitlement_test.go
@@ -39,6 +39,20 @@ func TestAccEntitlement_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudsmith_entitlement.test", "limit_num_downloads", "100"),
 				),
 			},
+			{
+				ResourceName: "cloudsmith_entitlement.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceState := s.RootModule().Resources["cloudsmith_entitlement.test"]
+					return fmt.Sprintf(
+						"%s.%s.%s",
+						resourceState.Primary.Attributes["namespace"],
+						resourceState.Primary.Attributes["repository"],
+						resourceState.Primary.ID,
+					), nil
+				},
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -591,5 +591,9 @@ func resourceRepository() *schema.Resource {
 				Default:     true,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -1,13 +1,28 @@
 package cloudsmith
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+func importRepository(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.Split(d.Id(), ".")
+	if len(idParts) != 2 {
+		return nil, fmt.Errorf(
+			"invalid import ID, must be of the form <organization_slug>.<repository_slug>, got: %s", d.Id(),
+		)
+	}
+
+	d.Set("namespace", idParts[0])
+	d.SetId(idParts[1])
+	return []*schema.ResourceData{d}, nil
+}
 
 func resourceRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
@@ -144,6 +159,12 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 	// created.
 	d.Set("namespace", namespace)
 
+	// since we allow import using either the slug or the slug_perm, we want to
+	// normalize the ID and always use the slug_perm when we can. This reset
+	// allows us to set the ID unconditionally, regardless of what the user
+	// passed.
+	d.SetId(repository.GetSlugPerm())
+
 	return nil
 }
 
@@ -245,6 +266,10 @@ func resourceRepository() *schema.Resource {
 		Read:   resourceRepositoryRead,
 		Update: resourceRepositoryUpdate,
 		Delete: resourceRepositoryDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: importRepository,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"cdn_url": {
@@ -590,10 +615,6 @@ func resourceRepository() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 			},
-		},
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/cloudsmith/resource_repository_geo_ip_rules_test.go
+++ b/cloudsmith/resource_repository_geo_ip_rules_test.go
@@ -76,6 +76,19 @@ func TestAccRepositoryGeoIpRules_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName: ResourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceState := s.RootModule().Resources[ResourceName]
+					return fmt.Sprintf(
+						"%s.%s",
+						resourceState.Primary.Attributes["namespace"],
+						resourceState.Primary.Attributes["repository"],
+					), nil
+				},
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccRepositoryGeoIpRulesConfigDefault,
 				Check: resource.ComposeTestCheckFunc(
 					testAccRepositoryGeoIpRulesCheckExists(ResourceName, "", "", "", ""),

--- a/cloudsmith/resource_repository_privileges_test.go
+++ b/cloudsmith/resource_repository_privileges_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // TestAccRepositoryPrivileges_basic spins up a repository with default options,
@@ -52,6 +53,19 @@ func TestAccRepositoryPrivileges_basic(t *testing.T) {
 						"slug":      "tf-test-team-privs-1",
 					}),
 				),
+			},
+			{
+				ResourceName: "cloudsmith_repository_privileges.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceState := s.RootModule().Resources["cloudsmith_repository_privileges.test"]
+					return fmt.Sprintf(
+						"%s.%s",
+						resourceState.Primary.Attributes["organization"],
+						resourceState.Primary.Attributes["repository"],
+					), nil
+				},
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/cloudsmith/resource_repository_test.go
+++ b/cloudsmith/resource_repository_test.go
@@ -58,6 +58,20 @@ func TestAccRepository_basic(t *testing.T) {
 					testAccRepositoryCheckExists("cloudsmith_repository.test"),
 				),
 			},
+			{
+				ResourceName: "cloudsmith_repository.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceState := s.RootModule().Resources["cloudsmith_repository.test"]
+					return fmt.Sprintf(
+						"%s.%s",
+						resourceState.Primary.Attributes["namespace"],
+						resourceState.Primary.Attributes["slug"],
+					), nil
+				},
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_deletion"},
+			},
 		},
 	})
 }

--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -281,5 +281,9 @@ func resourceService() *schema.Resource {
 				ForceNew: true,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_service_test.go
+++ b/cloudsmith/resource_service_test.go
@@ -51,6 +51,20 @@ func TestAccService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudsmith_service.test", "team.0.role", "Manager"),
 				),
 			},
+			{
+				ResourceName: "cloudsmith_service.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceState := s.RootModule().Resources["cloudsmith_service.test"]
+					return fmt.Sprintf(
+						"%s.%s",
+						resourceState.Primary.Attributes["organization"],
+						resourceState.Primary.Attributes["slug"],
+					), nil
+				},
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
 		},
 	})
 }

--- a/cloudsmith/resource_team.go
+++ b/cloudsmith/resource_team.go
@@ -185,5 +185,9 @@ func resourceTeam() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"Visible", "Hidden"}, false),
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_team.go
+++ b/cloudsmith/resource_team.go
@@ -1,13 +1,30 @@
 package cloudsmith
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+func importTeam(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	tflog.Error(ctx, "importing ohno")
+	idParts := strings.Split(d.Id(), ".")
+	if len(idParts) != 2 {
+		return nil, fmt.Errorf(
+			"invalid import ID, must be of the form <organization_slug>.<team_slug>, got: %s", d.Id(),
+		)
+	}
+
+	d.Set("organization", idParts[0])
+	d.SetId(idParts[1])
+	return []*schema.ResourceData{d}, nil
+}
 
 func resourceTeamCreate(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
@@ -72,6 +89,12 @@ func resourceTeamRead(d *schema.ResourceData, m interface{}) error {
 	// the value stored in resource state. We rely on ForceNew to ensure if it
 	// changes a new resource is created.
 	d.Set("organization", org)
+
+	// since we allow import using either the slug or the slug_perm, we want to
+	// normalize the ID and always use the slug_perm when we can. This reset
+	// allows us to set the ID unconditionally, regardless of what the user
+	// passed.
+	d.SetId(team.GetSlugPerm())
 
 	return nil
 }
@@ -144,6 +167,10 @@ func resourceTeam() *schema.Resource {
 		Update: resourceTeamUpdate,
 		Delete: resourceTeamDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: importTeam,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"description": {
 				Type:         schema.TypeString,
@@ -184,10 +211,6 @@ func resourceTeam() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"Visible", "Hidden"}, false),
 			},
-		},
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/cloudsmith/resource_team.go
+++ b/cloudsmith/resource_team.go
@@ -7,13 +7,11 @@ import (
 	"time"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func importTeam(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	tflog.Error(ctx, "importing ohno")
 	idParts := strings.Split(d.Id(), ".")
 	if len(idParts) != 2 {
 		return nil, fmt.Errorf(

--- a/cloudsmith/resource_team_test.go
+++ b/cloudsmith/resource_team_test.go
@@ -54,6 +54,19 @@ func TestAccTeam_basic(t *testing.T) {
 					testAccTeamCheckExists("cloudsmith_team.test"),
 				),
 			},
+			{
+				ResourceName: "cloudsmith_team.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceState := s.RootModule().Resources["cloudsmith_team.test"]
+					return fmt.Sprintf(
+						"%s.%s",
+						resourceState.Primary.Attributes["organization"],
+						resourceState.Primary.Attributes["slug"],
+					), nil
+				},
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/cloudsmith/resource_webhook.go
+++ b/cloudsmith/resource_webhook.go
@@ -450,5 +450,9 @@ func resourceWebhook() *schema.Resource {
 				Computed: true,
 			},
 		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }

--- a/cloudsmith/resource_webhook_test.go
+++ b/cloudsmith/resource_webhook_test.go
@@ -51,6 +51,20 @@ func TestAccWebhook_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudsmith_webhook.test", "template.1.template", "flap"),
 				),
 			},
+			{
+				ResourceName: "cloudsmith_webhook.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					resourceState := s.RootModule().Resources["cloudsmith_webhook.test"]
+					return fmt.Sprintf(
+						"%s.%s.%s",
+						resourceState.Primary.Attributes["namespace"],
+						resourceState.Primary.Attributes["repository"],
+						resourceState.Primary.ID,
+					), nil
+				},
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/docs/resources/entitlement.md
+++ b/docs/resources/entitlement.md
@@ -56,3 +56,11 @@ resource "cloudsmith_entitlement" "my_entitlement" {
 * `namespace` - Namespace to which this entitlement belongs.
 * `repository` - Repository to which this entitlement belongs.
 * `token` - The literal value of the token to be created.
+
+## Import
+
+This resource can be imported using the organization slug, the repository slug, and the entitlement slug:
+
+```shell
+terraform import cloudsmith_entitlement.my_entitlement my-organization.my-repository.3nt1lem3nT
+```

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -112,8 +112,8 @@ repository. This does not include collaborators, but applies to any member of th
 
 ## Import
 
-This resource can be imported using an ID made up of the slug:
+This resource can be imported using the organization slug, and the repository slug:
 
 ```shell
-terraform import cloudsmith_repository.my_repository my-repository-slug
+terraform import cloudsmith_repository.my_repository my-organization.my-repository
 ```

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -109,3 +109,11 @@ repository. This does not include collaborators, but applies to any member of th
 * `use_vulnerability_scanning` - If checked, vulnerability scanning will be enabled for all supported packages within this repository.
 * `user_entitlements_enabled` - If checked, users can use and manage their own user-specific entitlement token for the repository (if private). Otherwise, user-specific entitlements are disabled for all users.
 * `view_statistics` - This defines the minimum level of privilege required for a user to view repository statistics, to include entitlement-based usage, if applicable. If a user does not have the permission, they won't be able to view any statistics, either via the UI, API or CLI.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_repository.my_repository my-repository-slug
+```

--- a/docs/resources/repository_geo_ip_rules.md
+++ b/docs/resources/repository_geo_ip_rules.md
@@ -55,3 +55,11 @@ The following arguments are supported:
 * `cidr_deny` - (Optional) The list of IP Addresses for which to deny access to the Repository, expressed in CIDR notation.
 * `country_code_allow` - (Optional) The list of countries for which to allow access to the Repository, expressed in ISO 3166-1 country codes.
 * `country_code_deny` - (Optional) The list of countries for which to deny access to the Repository, expressed in ISO 3166-1 country codes.
+
+## Import
+
+This resource can be imported using the organization slug, and the repository slug:
+
+```shell
+terraform import cloudsmith_repository_geo_ip_rules.my_rules my-organization.my-repository
+```

--- a/docs/resources/repository_privileges.md
+++ b/docs/resources/repository_privileges.md
@@ -80,3 +80,11 @@ The following arguments are supported:
 * `user` - (Optional) Variable number of blocks containing users that should have repository privileges.
 	* `privilege` - (Required) The user's privilege level in the repository. Must be one of `Admin`, `Write`, or `Read`.
 	* `slug` - (Required) The slug/identifier of the user.
+
+## Import
+
+This resource can be imported using the organization slug, and the repository slug:
+
+```shell
+terraform import cloudsmith_repository_privileges.privs my-organization.my-repository
+```

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -48,3 +48,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `key` - The service's API key.
 * `slug` - The slug identifies the service in URIs or where a username is required.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_service.my_service my-service-slug
+```

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -12,7 +12,7 @@ provider "cloudsmith" {
 }
 
 data "cloudsmith_organization" "my_org" {
-	slug = "my-org"
+	slug = "my-organization"
 }
 
 resource "cloudsmith_team" "my_team" {
@@ -51,8 +51,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-This resource can be imported using an ID made up of the slug:
+This resource can be imported using the organization slug, and the service slug:
 
 ```shell
-terraform import cloudsmith_service.my_service my-service-slug
+terraform import cloudsmith_service.my_service my-organization.my-service
 ```

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -56,3 +56,5 @@ This resource can be imported using the organization slug, and the service slug:
 ```shell
 terraform import cloudsmith_service.my_service my-organization.my-service
 ```
+
+NOTE: It's not possible to retrieve a service's API key via the Cloudsmith API after creation, so when we import a service the key is unavailable. If the API key is needed for use within Terraform (to be passed to other resources) then the resource needs to be tainted and recreated (or otherwise created fresh within Terraform).

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -36,3 +36,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `slug_perm` - The slug_perm immutably identifies the team. It will never change once a team has been created.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_team.my_team my-team-slug
+```

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -12,7 +12,7 @@ provider "cloudsmith" {
 }
 
 data "cloudsmith_organization" "my_org" {
-    slug = "my-org"
+    slug = "my-organization"
 }
 
 resource "cloudsmith_team" "my_team" {
@@ -39,8 +39,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-This resource can be imported using an ID made up of the slug:
+This resource can be imported using the organization slug, and the team slug:
 
 ```shell
-terraform import cloudsmith_team.my_team my-team-slug
+terraform import cloudsmith_team.my_team my-organization.my-team
 ```

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -72,8 +72,8 @@ resource "cloudsmith_webhook" "my_webhook" {
 
 ## Import
 
-This resource can be imported using an ID made up of the slug:
+This resource can be imported using the organization slug, the repository slug, and the webhook slug:
 
 ```shell
-terraform import cloudsmith_webhook.my_webhook my-webhook-slug
+terraform import cloudsmith_webhook.my_webhook my-organization.my-repository.w3bh0okS1uG
 ```

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -69,3 +69,11 @@ resource "cloudsmith_webhook" "my_webhook" {
 * `slug_perm` - The slug_perm immutably identifies the webhook. It will never change once a webhook has been created.
 * `updated_at` - ISO 8601 timestamp at which the webhook was updated.
 * `updated_by` - The user/account that updated the webhook.
+
+## Import
+
+This resource can be imported using an ID made up of the slug:
+
+```shell
+terraform import cloudsmith_webhook.my_webhook my-webhook-slug
+```


### PR DESCRIPTION
This PR adds the ability to `terraform import` all available resources. This functionality is crucial for users migrating existing resources into Terraform as we expand the provider.
