### PR TITLE
feat(eng-2375): Add package_query_string to policies

### DIFF
--- a/cloudsmith/resource_license_policy.go
+++ b/cloudsmith/resource_license_policy.go
@@ -20,6 +20,7 @@ const (
 	OnViolationQuarantine string = "on_violation_quarantine"
 	SlugPerm              string = "slug_perm"
 	SpdxIdentifiers       string = "spdx_identifiers"
+	PackageQueryString    string = "package_query_string"
 	UpdatedAt             string = "updated_at"
 	Organization          string = "organization"
 )
@@ -49,6 +50,7 @@ func resourceLicensePolicyCreate(d *schema.ResourceData, m interface{}) error {
 		Name:                  requiredString(d, Name),
 		OnViolationQuarantine: optionalBool(d, OnViolationQuarantine),
 		SpdxIdentifiers:       expandStrings(d, SpdxIdentifiers),
+		PackageQueryString:    nullableString(d, PackageQueryString),
 	})
 
 	licensePolicy, resp, err := pc.APIClient.OrgsApi.OrgsLicensePolicyCreateExecute(req)
@@ -90,6 +92,7 @@ func resourceLicensePolicyUpdate(d *schema.ResourceData, m interface{}) error {
 		Name:                  requiredString(d, Name),
 		OnViolationQuarantine: optionalBool(d, OnViolationQuarantine),
 		SpdxIdentifiers:       expandStrings(d, SpdxIdentifiers),
+		PackageQueryString:    nullableString(d, PackageQueryString),
 	})
 	licensePolicy, resp, err := pc.APIClient.OrgsApi.OrgsLicensePolicyUpdateExecute(req)
 	if err != nil {
@@ -166,6 +169,7 @@ func resourceLicensePolicyRead(d *schema.ResourceData, m interface{}) error {
 	_ = d.Set(AllowUnknownLicenses, licensePolicy.GetAllowUnknownLicenses())
 	_ = d.Set(SlugPerm, licensePolicy.GetSlugPerm())
 	_ = d.Set(SpdxIdentifiers, flattenStrings(licensePolicy.GetSpdxIdentifiers()))
+	_ = d.Set(PackageQueryString, licensePolicy.GetPackageQueryString())
 	_ = d.Set(UpdatedAt, licensePolicy.GetUpdatedAt().String())
 
 	// organization is not returned from the read
@@ -231,6 +235,11 @@ func resourceLicensePolicy() *schema.Resource {
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 				Required: true,
+			},
+			PackageQueryString: {
+				Type:        schema.TypeString,
+				Description: "A search / filter string of packages to include in the policy.",
+				Optional:    true,
 			},
 			UpdatedAt: {
 				Type:        schema.TypeString,

--- a/cloudsmith/resource_license_policy_test.go
+++ b/cloudsmith/resource_license_policy_test.go
@@ -139,6 +139,7 @@ resource "cloudsmith_license_policy" "test" {
 	spdx_identifiers        = ["Apache-2.0"]
 	on_violation_quarantine = true
 	allow_unknown_licenses  = true
+	package_query_string = "format:python AND downloads:>50"
 	organization            = "%s"
 }
 `, os.Getenv("CLOUDSMITH_NAMESPACE"))

--- a/cloudsmith/resource_license_policy_test.go
+++ b/cloudsmith/resource_license_policy_test.go
@@ -139,7 +139,7 @@ resource "cloudsmith_license_policy" "test" {
 	spdx_identifiers        = ["Apache-2.0"]
 	on_violation_quarantine = true
 	allow_unknown_licenses  = true
-	package_query_string = "format:python AND downloads:>50"
+	package_query_string    = "format:python AND downloads:>50"
 	organization            = "%s"
 }
 `, os.Getenv("CLOUDSMITH_NAMESPACE"))

--- a/cloudsmith/resource_vulnerability_policy.go
+++ b/cloudsmith/resource_vulnerability_policy.go
@@ -41,6 +41,7 @@ func resourceVulnerabilityPolicyCreate(d *schema.ResourceData, m interface{}) er
 		Description:           nullableString(d, Description),
 		Name:                  requiredString(d, Name),
 		OnViolationQuarantine: optionalBool(d, OnViolationQuarantine),
+		PackageQueryString:    nullableString(d, PackageQueryString),
 	})
 
 	vulnerabilityPolicy, _, err := pc.APIClient.OrgsApi.OrgsVulnerabilityPolicyCreateExecute(req)
@@ -79,6 +80,7 @@ func resourceVulnerabilityPolicyUpdate(d *schema.ResourceData, m interface{}) er
 		Description:           nullableString(d, Description),
 		Name:                  requiredString(d, Name),
 		OnViolationQuarantine: optionalBool(d, OnViolationQuarantine),
+		PackageQueryString:    nullableString(d, PackageQueryString),
 	})
 
 	vulnerabilityPolicy, _, err := pc.APIClient.OrgsApi.OrgsVulnerabilityPolicyUpdateExecute(req)
@@ -153,6 +155,7 @@ func resourceVulnerabilityPolicyRead(d *schema.ResourceData, m interface{}) erro
 	_ = d.Set(SlugPerm, vulnerabilityPolicy.GetSlugPerm())
 	_ = d.Set(MinSeverity, vulnerabilityPolicy.GetMinSeverity())
 	_ = d.Set(AllowUnknownSeverity, vulnerabilityPolicy.GetAllowUnknownSeverity())
+	_ = d.Set(PackageQueryString, vulnerabilityPolicy.GetPackageQueryString())
 	_ = d.Set(UpdatedAt, vulnerabilityPolicy.GetUpdatedAt().String())
 
 	// organization is not returned from the read
@@ -216,6 +219,11 @@ func resourceVulnerabilityPolicy() *schema.Resource {
 				Description: "Allow an unknown severity level.",
 				Optional:    true,
 				Computed:    true,
+			},
+			PackageQueryString: {
+				Type:        schema.TypeString,
+				Description: "A search / filter string of packages to include in the policy.",
+				Optional:    true,
 			},
 			UpdatedAt: {
 				Type:        schema.TypeString,

--- a/cloudsmith/resource_vulnerability_policy_test.go
+++ b/cloudsmith/resource_vulnerability_policy_test.go
@@ -138,6 +138,7 @@ resource "cloudsmith_vulnerability_policy" "test" {
 	min_severity            = "High"
 	on_violation_quarantine = true
 	allow_unknown_severity  = true
+	package_query_string = "format:python AND downloads:>50"
 	organization            = "%s"
 }
 `, os.Getenv("CLOUDSMITH_NAMESPACE"))

--- a/cloudsmith/resource_vulnerability_policy_test.go
+++ b/cloudsmith/resource_vulnerability_policy_test.go
@@ -138,7 +138,7 @@ resource "cloudsmith_vulnerability_policy" "test" {
 	min_severity            = "High"
 	on_violation_quarantine = true
 	allow_unknown_severity  = true
-	package_query_string = "format:python AND downloads:>50"
+	package_query_string    = "format:python AND downloads:>50"
 	organization            = "%s"
 }
 `, os.Getenv("CLOUDSMITH_NAMESPACE"))

--- a/docs/resources/license_policy.md
+++ b/docs/resources/license_policy.md
@@ -20,6 +20,7 @@ resource "cloudsmith_license_policy" "my_license_policy" {
     description             = "My license policy"
     spdx_identifiers        = ["Apache-2.0"]
     on_violation_quarantine = true
+    package_query_string    = "format:python AND downloads:>50" 
     organization            = "my-organization"
 }
 ```
@@ -34,6 +35,7 @@ The following arguments are supported:
 * `spdx_identifiers` - (Required) The licenses to deny.
 * `on_violation_quarantine` - (Optional) On violation of the license policy, quarantine violating packages.
 * `allow_unknown_licenses` - (Optional) Allow unknown licenses within the policy.
+* `package_query_string` - (Optional) A search / filter string of packages to include in the policy.
 
 ## Import
 

--- a/docs/resources/vulnerability_policy.md
+++ b/docs/resources/vulnerability_policy.md
@@ -21,6 +21,7 @@ resource "cloudsmith_vulnerability_policy" "my_vulnerability_policy" {
     min_severity            = "Medium"
     on_violation_quarantine = true
     allow_unknown_severity  = false
+    package_query_string    = "format:python AND downloads:>50" 
     organization            = "my-organization"
 }
 ```
@@ -35,6 +36,7 @@ The following arguments are supported:
 * `min_severity` - (Optional) The minimum severity level where a policy violation will be flagged.
 * `on_violation_quarantine` - (Optional) On violation of the vulnerability policy, quarantine violating packages.
 * `allow_unknown_severity` - (Optional) Allow an unknown severity level.
+* `package_query_string` - (Optional) A search / filter string of packages to include in the policy.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsmith-io/terraform-provider-cloudsmith
 go 1.19
 
 require (
-	github.com/cloudsmith-io/cloudsmith-api-go v0.0.26
+	github.com/cloudsmith-io/cloudsmith-api-go v0.0.27
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/samber/lo v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.26 h1:RNY6aIPeJcWESfmbh57z+jNV1kUnsO4YNhtkZViPyPM=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.26/go.mod h1:XgzmIrQLx3aBku6exjIA9cBe1Tc0hHXWnZbwYakKnOI=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.27 h1:j33ZpMqXbfbC55Z/ufnCJMAAD2XYNJ/3sp/lkNM5gHE=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.27/go.mod h1:XgzmIrQLx3aBku6exjIA9cBe1Tc0hHXWnZbwYakKnOI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.26 h1:RNY6aIPeJcWESfmbh57z+jNV1kUnsO4YNhtkZViPyPM=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.26/go.mod h1:XgzmIrQLx3aBku6exjIA9cBe1Tc0hHXWnZbwYakKnOI=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.27 h1:j33ZpMqXbfbC55Z/ufnCJMAAD2XYNJ/3sp/lkNM5gHE=
 github.com/cloudsmith-io/cloudsmith-api-go v0.0.27/go.mod h1:XgzmIrQLx3aBku6exjIA9cBe1Tc0hHXWnZbwYakKnOI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
This PR adds the `policy_query_string` option to `cloudsmith_license_policy` and `cloudsmith_vulnerability_policy` resources to target specific packages to apply to polices with Terraform.