### PR TITLE
option to suppress warnings for key mismatch on service object (margueritepd)

### DIFF
--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -275,12 +275,6 @@ func resourceService() *schema.Resource {
 				Computed:    true,
 				Sensitive:   true,
 			},
-			"warn_on_key_difference": {
-				Type:        schema.TypeBool,
-				Description: "Whether to warn if service's current key differs from key in state.",
-				Optional:    true,
-				Default:     true,
-			},
 			"name": {
 				Type:         schema.TypeString,
 				Description:  "A descriptive name for the service.",
@@ -326,6 +320,12 @@ func resourceService() *schema.Resource {
 					},
 				},
 				Optional: true,
+			},
+			"warn_on_key_difference": {
+				Type:        schema.TypeBool,
+				Description: "Whether to warn if service's current key differs from key in state.",
+				Optional:    true,
+				Default:     true,
 			},
 		},
 	}

--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -153,28 +153,31 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 	// into Terraform. This can be accomplished by tainting.
 	var diags diag.Diagnostics
 	existingKey := requiredString(d, "key")
-	if existingKey == importSentinel {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "API key unavailable for imported services",
-			Detail: "API keys are only available via the Cloudsmith API at the time a service " +
-				"is created, and therefore it is not possible to retrieve the current API key for " +
-				"a service which has been imported. If the API key value is needed within Terraform" +
-				"then the resource can be tainted post-import to recreate it and store the key.",
-			AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
-		})
-	} else {
-		existingLastFour := existingKey[len(existingKey)-4:]
-		newLastFour := service.GetKey()[len(service.GetKey())-4:]
-		if existingLastFour != newLastFour {
+	if requiredBool(d, "warn_on_key_difference") {
+		if existingKey == importSentinel {
+
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  "API key has changed",
-				Detail: "API key for this service has changed outside of Terraform. If this " +
-					"key is used within Terraform the resource must be tainted or otherwise " +
-					"recreated to retrieve the new value.",
+				Summary:  "API key unavailable for imported services",
+				Detail: "API keys are only available via the Cloudsmith API at the time a service " +
+					"is created, and therefore it is not possible to retrieve the current API key for " +
+					"a service which has been imported. If the API key value is needed within Terraform" +
+					"then the resource can be tainted post-import to recreate it and store the key.",
 				AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
 			})
+		} else {
+			existingLastFour := existingKey[len(existingKey)-4:]
+			newLastFour := service.GetKey()[len(service.GetKey())-4:]
+			if existingLastFour != newLastFour {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "API key has changed",
+					Detail: "API key for this service has changed outside of Terraform. If this " +
+						"key is used within Terraform the resource must be tainted or otherwise " +
+						"recreated to retrieve the new value.",
+					AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
+				})
+			}
 		}
 	}
 
@@ -271,6 +274,12 @@ func resourceService() *schema.Resource {
 				Description: "The service's API key.",
 				Computed:    true,
 				Sensitive:   true,
+			},
+			"warn_on_key_difference": {
+				Type:        schema.TypeBool,
+				Description: "Whether to warn if service's current key differs from key in state.",
+				Optional:    true,
+				Default:     true,
 			},
 			"name": {
 				Type:         schema.TypeString,

--- a/cloudsmith/resource_service_test.go
+++ b/cloudsmith/resource_service_test.go
@@ -81,7 +81,7 @@ func TestAccService_basic(t *testing.T) {
 					), nil
 				},
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"key"},
+				ImportStateVerifyIgnore: []string{"key", "warn_on_key_difference"}, // Exclude warn_on_key_difference from the verification
 			},
 		},
 	})

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `team` - (Optional) Variable number of blocks containing team assignments for this service.
 	* `role` - (Optional) The service's role in the team. If defined, must be one of `Member` or `Manager`.
 	* `slug` - (Required) The team the service should be added to.
+* `warn_on_key_difference` - (Optional) Whether to warn if service's current key differs from key in state.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Raising this on behalf of @margueritepd in order to let the tests run with correct values.

## Context
We don't want to store credentials in state. The cloudsmith provider stores the service account's key in state, but continues to work even if the key in the state doesn't match reality, in which case it issues a warning. To get around storing the key in state, we will have a workflow where, after the service account is provisioned, we will rotate the API key via the UI. The only problem with this is that warnings will be issued in future TF plans and applies which we have no intention of addressing.

## This change

This change adds the option to suppress warnings about the key in state not matching reality.

## Testing

I compiled this locally and added it to a local terraform plugin dir and ran some tests.

On unmodified terraform code to provision a service account, where the key in state matches reality:
Terraform wants to add a new attribute: warn_on_key_difference = true.
Applying will set this attribute in the state.

On unmodified terraform code to provision a service account, where the key in state does NOT match reality:
The warning is issued, and the plan returns with Terraform wanting to add the new attribute: warn_on_key_difference = true
if I update the terraform code so that warn_on_key_difference = false and plan, the warning is still issued, and terraform wants to add the new attribute: warn_on_key_difference = false
After applying, the warning is no longer issued on subsequent terraform plans.

## Alternatives considered

Ideally we would be able to turn off storing the key in state completely. That would remove the need to rotate the key in the UI afterward. But that seemed like a more invasive change which I was not confident executing.
I tried adding lifecycle.ignore_changes to the resource but since the key is a computed attribute and not one specified in the terraform code, this did nothing.

## Feedback i'm looking for

Let me know if you want me to try another approach, or if you want me to do further testing!