### PR TITLE
Add optional flag to disable api key return

### DIFF
--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -132,6 +132,8 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	req := pc.APIClient.OrgsApi.OrgsServicesRead(pc.Auth, org, d.Id())
 
+	const lastFourChars = 4
+
 	service, resp, err := pc.APIClient.OrgsApi.OrgsServicesReadExecute(req)
 	if err != nil {
 		if is404(resp) {
@@ -166,9 +168,8 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 				AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
 			})
 		} else {
-			d.Set("key", "**redacted**")
-			existingLastFour := existingKey[len(existingKey)-4:]
-			newLastFour := service.GetKey()[len(service.GetKey())-4:]
+			existingLastFour := existingKey[len(existingKey)-lastFourChars:]
+			newLastFour := service.GetKey()[len(service.GetKey())-lastFourChars:]
 			if existingLastFour != newLastFour {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
@@ -180,6 +181,8 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 				})
 			}
 		}
+	} else {
+		d.Set("key", "**redacted**")
 	}
 
 	// organization is not returned from the service read endpoint, so we can

--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -105,8 +105,9 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interf
 	// Unfortunately this means that if the user needs to rotate the service's
 	// API key then the only way to do it and have it reflected properly in
 	// Terraform is to taint the whole resource and let Terraform recreate it.
-	d.Set("key", service.GetKey())
-
+	if requiredBool(d, "return_api_key") {
+		d.Set("key", service.GetKey())
+	}
 	checkerFunc := func() error {
 		req := pc.APIClient.OrgsApi.OrgsServicesRead(pc.Auth, org, d.Id())
 		if _, resp, err := pc.APIClient.OrgsApi.OrgsServicesReadExecute(req); err != nil {
@@ -152,29 +153,32 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 	// they'll need to recreate the resource if they want to pull the new key
 	// into Terraform. This can be accomplished by tainting.
 	var diags diag.Diagnostics
-	existingKey := requiredString(d, "key")
-	if existingKey == importSentinel {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "API key unavailable for imported services",
-			Detail: "API keys are only available via the Cloudsmith API at the time a service " +
-				"is created, and therefore it is not possible to retrieve the current API key for " +
-				"a service which has been imported. If the API key value is needed within Terraform" +
-				"then the resource can be tainted post-import to recreate it and store the key.",
-			AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
-		})
-	} else {
-		existingLastFour := existingKey[len(existingKey)-4:]
-		newLastFour := service.GetKey()[len(service.GetKey())-4:]
-		if existingLastFour != newLastFour {
+	if requiredBool(d, "return_api_key") {
+		existingKey := requiredString(d, "key")
+		if existingKey == importSentinel {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  "API key has changed",
-				Detail: "API key for this service has changed outside of Terraform. If this " +
-					"key is used within Terraform the resource must be tainted or otherwise " +
-					"recreated to retrieve the new value.",
+				Summary:  "API key unavailable for imported services",
+				Detail: "API keys are only available via the Cloudsmith API at the time a service " +
+					"is created, and therefore it is not possible to retrieve the current API key for " +
+					"a service which has been imported. If the API key value is needed within Terraform" +
+					"then the resource can be tainted post-import to recreate it and store the key.",
 				AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
 			})
+		} else {
+			d.Set("key", "disabled")
+			existingLastFour := existingKey[len(existingKey)-4:]
+			newLastFour := service.GetKey()[len(service.GetKey())-4:]
+			if existingLastFour != newLastFour {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "API key has changed",
+					Detail: "API key for this service has changed outside of Terraform. If this " +
+						"key is used within Terraform, the resource must be tainted or otherwise " +
+						"recreated to retrieve the new value.",
+					AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
+				})
+			}
 		}
 	}
 
@@ -317,6 +321,12 @@ func resourceService() *schema.Resource {
 					},
 				},
 				Optional: true,
+			},
+			"return_api_key": {
+				Type:        schema.TypeBool,
+				Description: "Whether to include the service's API key in Terraform state.",
+				Optional:    true,
+				Default:     true,
 			},
 		},
 	}

--- a/cloudsmith/resource_service.go
+++ b/cloudsmith/resource_service.go
@@ -105,7 +105,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interf
 	// Unfortunately this means that if the user needs to rotate the service's
 	// API key then the only way to do it and have it reflected properly in
 	// Terraform is to taint the whole resource and let Terraform recreate it.
-	if requiredBool(d, "return_api_key") {
+	if requiredBool(d, "store_api_key") {
 		d.Set("key", service.GetKey())
 	}
 	checkerFunc := func() error {
@@ -153,7 +153,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 	// they'll need to recreate the resource if they want to pull the new key
 	// into Terraform. This can be accomplished by tainting.
 	var diags diag.Diagnostics
-	if requiredBool(d, "return_api_key") {
+	if requiredBool(d, "store_api_key") {
 		existingKey := requiredString(d, "key")
 		if existingKey == importSentinel {
 			diags = append(diags, diag.Diagnostic{
@@ -166,7 +166,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 				AttributePath: cty.Path{cty.GetAttrStep{Name: "key"}},
 			})
 		} else {
-			d.Set("key", "disabled")
+			d.Set("key", "**redacted**")
 			existingLastFour := existingKey[len(existingKey)-4:]
 			newLastFour := service.GetKey()[len(service.GetKey())-4:]
 			if existingLastFour != newLastFour {
@@ -322,7 +322,7 @@ func resourceService() *schema.Resource {
 				},
 				Optional: true,
 			},
-			"return_api_key": {
+			"store_api_key": {
 				Type:        schema.TypeBool,
 				Description: "Whether to include the service's API key in Terraform state.",
 				Optional:    true,

--- a/cloudsmith/resource_service_test.go
+++ b/cloudsmith/resource_service_test.go
@@ -17,6 +17,7 @@ import (
 // NOTE: It is not necessary to check properties that have been explicitly set
 // as Terraform performs a drift/plan check after every step anyway. Only
 // computed properties need explicitly checked.
+// TestAccService_basic runs a series of tests for the cloudsmith_service resource.
 func TestAccService_basic(t *testing.T) {
 	t.Parallel()
 
@@ -70,6 +71,14 @@ func TestAccService_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccServiceConfigNoAPIKey,
+				Check: resource.ComposeTestCheckFunc(
+					testAccServiceCheckExists("cloudsmith_service.test"),
+					// check that the key attribute is explicitly an empty string
+					resource.TestCheckResourceAttr("cloudsmith_service.test", "key", "disabled"),
+				),
+			},
+			{
 				ResourceName: "cloudsmith_service.test",
 				ImportState:  true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
@@ -81,7 +90,7 @@ func TestAccService_basic(t *testing.T) {
 					), nil
 				},
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"key"},
+				ImportStateVerifyIgnore: []string{"key", "return_api_key"},
 			},
 		},
 	})
@@ -138,6 +147,14 @@ func testAccServiceCheckExists(resourceName string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+var testAccServiceConfigNoAPIKey = fmt.Sprintf(`
+resource "cloudsmith_service" "test" {
+	name            = "TF Test Service No API Key"
+	organization    = "%s"
+	return_api_key  = false
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE"))
 
 var testAccServiceConfigBasic = fmt.Sprintf(`
 resource "cloudsmith_service" "test" {

--- a/cloudsmith/resource_service_test.go
+++ b/cloudsmith/resource_service_test.go
@@ -75,7 +75,7 @@ func TestAccService_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccServiceCheckExists("cloudsmith_service.test"),
 					// check that the key attribute is explicitly an empty string
-					resource.TestCheckResourceAttr("cloudsmith_service.test", "key", "disabled"),
+					resource.TestCheckResourceAttr("cloudsmith_service.test", "key", "**redacted**"),
 				),
 			},
 			{
@@ -90,7 +90,7 @@ func TestAccService_basic(t *testing.T) {
 					), nil
 				},
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"key", "return_api_key"},
+				ImportStateVerifyIgnore: []string{"key", "store_api_key"},
 			},
 		},
 	})
@@ -152,7 +152,7 @@ var testAccServiceConfigNoAPIKey = fmt.Sprintf(`
 resource "cloudsmith_service" "test" {
 	name            = "TF Test Service No API Key"
 	organization    = "%s"
-	return_api_key  = false
+	store_api_key  = false
 }
 `, os.Getenv("CLOUDSMITH_NAMESPACE"))
 

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -41,12 +41,12 @@ The following arguments are supported:
 * `team` - (Optional) Variable number of blocks containing team assignments for this service.
 	* `role` - (Optional) The service's role in the team. If defined, must be one of `Member` or `Manager`.
 	* `slug` - (Required) The team the service should be added to.
-* `return_api_key` - (Optional) The service's API key to be returned in state. Defaults to `true`. If se to `false`, the "key" value is replaced with `disabled`
+* `store_api_key` - (Optional) The service's API key to be returned in state. Defaults to `true`. If set to `false`, the "key" value is replaced with `disabled`
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `key` - The service's API key. If `return_api_key` is set to false, the value returned will equal to `disabled`
+* `key` - The service's API key. If `store_api_key` is set to false, the value returned will equal to `disabled`
 * `slug` - The slug identifies the service in URIs or where a username is required.
 
 ## Import

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -41,12 +41,12 @@ The following arguments are supported:
 * `team` - (Optional) Variable number of blocks containing team assignments for this service.
 	* `role` - (Optional) The service's role in the team. If defined, must be one of `Member` or `Manager`.
 	* `slug` - (Required) The team the service should be added to.
-
+* `return_api_key` - (Optional) The service's API key to be returned in state. Defaults to `true`. If se to `false`, the "key" value is replaced with `disabled`
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `key` - The service's API key.
+* `key` - The service's API key. If `return_api_key` is set to false, the value returned will equal to `disabled`
 * `slug` - The slug identifies the service in URIs or where a username is required.
 
 ## Import


### PR DESCRIPTION
Context:

We are currently returning the service account API key to state which causes warnings when rotating the keys outside of the state. The aim of this PR is to provide the option to not return the API key at all which provides additional security and suppresses the warnings as it defaults the "key" value to "disabled"