### PR TITLE
PRO-752: Calculate package checksum locally when downloaded

### DIFF
--- a/cloudsmith/data_source_package.go
+++ b/cloudsmith/data_source_package.go
@@ -85,6 +85,7 @@ func dataSourcePackageRead(d *schema.ResourceData, m interface{}) error {
 			if err != nil {
 				return err
 			}
+			fmt.Println("Package pulled again due to checksum mismatch.")
 
 			// Calculate checksums for the downloaded file again
 			localChecksums, err := calculateChecksums(outputPath)

--- a/cloudsmith/data_source_package_test.go
+++ b/cloudsmith/data_source_package_test.go
@@ -75,7 +75,7 @@ func TestAccPackage_data(t *testing.T) {
 						return uploadPackage(testAccProvider.Meta().(*providerConfig), true)
 					},
 					func(s *terraform.State) error {
-						filePath := filepath.Join("/Users/bblizniak/Desktop/terrafor_test/2", "hello.txt")
+						filePath := filepath.Join(os.TempDir(), "hello.txt")
 						if _, err := os.Stat(filePath); os.IsNotExist(err) {
 							return fmt.Errorf("file does not exist at path: %s", filePath)
 						}

--- a/cloudsmith/data_source_package_test.go
+++ b/cloudsmith/data_source_package_test.go
@@ -36,7 +36,7 @@ func TestAccPackage_data(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudsmith_repository.test", "name", dsPackageTestRepository),
 					// Custom TestCheckFunc to upload the package and wait for sync after repository creation
 					func(s *terraform.State) error {
-						return uploadPackage(testAccProvider.Meta().(*providerConfig))
+						return uploadPackage(testAccProvider.Meta().(*providerConfig), false)
 					},
 				),
 			},
@@ -58,6 +58,33 @@ func TestAccPackage_data(t *testing.T) {
 						if _, err := os.Stat(filePath); os.IsNotExist(err) {
 							return fmt.Errorf("file does not exist at path: %s", filePath)
 						}
+						expectedContent := "Hello world"
+						if err := checkFileContent(filePath, expectedContent); err != nil {
+							return fmt.Errorf("file content check failed: %w", err)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccPackageDataReadPackageDownloadRepublish(dsPackageTestNamespace, dsPackageTestRepository),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cloudsmith_package.test", "namespace", dsPackageTestNamespace),
+					resource.TestCheckResourceAttr("data.cloudsmith_package.test", "repository", dsPackageTestRepository),
+					func(s *terraform.State) error {
+						return uploadPackage(testAccProvider.Meta().(*providerConfig), true)
+					},
+					func(s *terraform.State) error {
+						filePath := filepath.Join("/Users/bblizniak/Desktop/terrafor_test/2", "hello.txt")
+						if _, err := os.Stat(filePath); os.IsNotExist(err) {
+							return fmt.Errorf("file does not exist at path: %s", filePath)
+						}
+
+						expectedContent := "Hello world updated content"
+						if err := checkFileContent(filePath, expectedContent); err != nil {
+							return fmt.Errorf("file content check failed: %w", err)
+						}
+
 						return nil
 					},
 				),
@@ -65,9 +92,25 @@ func TestAccPackage_data(t *testing.T) {
 		},
 	})
 }
+func checkFileContent(filePath string, expectedContent string) error {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
 
-func uploadPackage(pc *providerConfig) error {
+	if string(content) != expectedContent {
+		return fmt.Errorf("file content does not match expected. Got: %s, Expected: %s", content, expectedContent)
+	}
+
+	return nil
+}
+
+func uploadPackage(pc *providerConfig, republish bool) error {
 	fileContent := []byte("Hello world")
+	if republish {
+		updatedContent := []byte(" updated content")
+		fileContent = append(fileContent, updatedContent...)
+	}
 
 	initPayload := cloudsmith.PackageFileUploadRequest{
 		Filename:       "hello.txt",
@@ -154,6 +197,7 @@ func testAccPackageDataSetup(namespace, repository string) string {
 		resource "cloudsmith_repository" "test" {
 			name      = "%s"
 			namespace = "%s"
+			replace_packages_by_default = true
 		}
 		`, repository, namespace)
 }
@@ -163,6 +207,7 @@ func testAccPackageDataReadPackage(namespace, repository string) string {
 		resource "cloudsmith_repository" "test" {
 			name      = "%s"
 			namespace = "%s"
+			replace_packages_by_default = true
 		}
 
 		data "cloudsmith_package_list" "test" {
@@ -183,6 +228,29 @@ func testAccPackageDataReadPackageDownload(namespace, repository string) string 
 		resource "cloudsmith_repository" "test" {
 			name      = "%s"
 			namespace = "%s"
+			replace_packages_by_default = true
+		}
+
+		data "cloudsmith_package_list" "test" {
+			repository = "%s"
+			namespace  = "%s"
+		}
+
+		data "cloudsmith_package" "test" {
+			repository = "%s"
+			namespace  = "%s"
+			identifier = data.cloudsmith_package_list.test.packages[0].slug_perm
+			download   = true
+		}
+		`, repository, namespace, repository, namespace, repository, namespace)
+}
+
+func testAccPackageDataReadPackageDownloadRepublish(namespace, repository string) string {
+	return fmt.Sprintf(`
+		resource "cloudsmith_repository" "test" {
+			name      = "%s"
+			namespace = "%s"
+			replace_packages_by_default = true
 		}
 
 		data "cloudsmith_package_list" "test" {

--- a/cloudsmith/data_source_package_test.go
+++ b/cloudsmith/data_source_package_test.go
@@ -196,21 +196,5 @@ func testAccPackageDataReadPackageDownload(namespace, repository string) string 
 			identifier = data.cloudsmith_package_list.test.packages[0].slug_perm
 			download   = true
 		}
-
-		output "md5_checksum" {
-			value = data.cloudsmith_package.test.checksum_md5
-		}
-
-		output "sha1_checksum" {
-			value = data.cloudsmith_package.test.checksum_sha1
-		}
-
-		output "sha256_checksum" {
-			value = data.cloudsmith_package.test.checksum_sha256
-		}
-
-		output "sha512_checksum" {
-			value = data.cloudsmith_package.test.checksum_sha512
-		}
 		`, repository, namespace, repository, namespace, repository, namespace)
 }

--- a/cloudsmith/data_source_package_test.go
+++ b/cloudsmith/data_source_package_test.go
@@ -196,5 +196,21 @@ func testAccPackageDataReadPackageDownload(namespace, repository string) string 
 			identifier = data.cloudsmith_package_list.test.packages[0].slug_perm
 			download   = true
 		}
+
+		output "md5_checksum" {
+			value = data.cloudsmith_package.test.checksum_md5
+		}
+
+		output "sha1_checksum" {
+			value = data.cloudsmith_package.test.checksum_sha1
+		}
+
+		output "sha256_checksum" {
+			value = data.cloudsmith_package.test.checksum_sha256
+		}
+
+		output "sha512_checksum" {
+			value = data.cloudsmith_package.test.checksum_sha512
+		}
 		`, repository, namespace, repository, namespace, repository, namespace)
 }

--- a/docs/data-sources/package.md
+++ b/docs/data-sources/package.md
@@ -39,6 +39,7 @@ data "cloudsmith_package" "test" {
 -   `identifier` (Required): The identifier for the package.
 -   `download` (Optional): If set to true, the package will be downloaded. Defaults to false. If set to false, the CDN URL will be available in the `output_path`.
 -   `download_dir` (Optional): The directory where the file will be downloaded to. If not set and `download` is set to `true`, it will default to the operating system's default temporary directory and save the file there.
+-   `ignore_checksums` (Optional): If set to `true`, any mismatched checksum from our API and local check will be ignored and download the package if `download` is set to `true`.
 
 ## Attribute Reference
 

--- a/docs/data-sources/package.md
+++ b/docs/data-sources/package.md
@@ -43,10 +43,10 @@ data "cloudsmith_package" "test" {
 ## Attribute Reference
 
 -   `cdn_url`: The URL of the package to download. This attribute is computed and available only when the `download` argument is set to `false`.
--   `checksum_md5`: MD5 hash of the package.
--   `checksum_sha1`: SHA1 hash of the package.
--   `checksum_sha256`: SHA256 hash of the package.
--   `checksum_sha512`: SHA512 hash of the package.
+-   `checksum_md5`: MD5 hash of the downloaded package. If `download` is set to `false`, the checksum is returned from the package API instead.
+-   `checksum_sha1`: SHA1 hash of the downloaded package.If `download` is set to `false`, the checksum is returned from the package API instead.
+-   `checksum_sha256`: SHA256 hash of the downloaded package.If `download` is set to `false`, the checksum is returned from the package API instead.
+-   `checksum_sha512`: SHA512 hash of the downloaded package.If `download` is set to `false`, the checksum is returned from the package API instead.
 -   `format`: The format of the package.
 -   `is_sync_awaiting`: Indicates whether the package is awaiting synchronization.
 -   `is_sync_completed`: Indicates whether the package synchronization has completed.


### PR DESCRIPTION
Previously, we were grabbing the package checksum via our API which meant that the checksum could be out-of-sync whenever a package is re-published due to caching. This commit ensures that the checksums that are being returned are from the downloaded package and when the package is not downloaded, the checksums will then be returned from the API.