### PR TITLE
Update flat-example and add iterative-example

### DIFF
--- a/examples/flat-example/org-deny-policy.tf
+++ b/examples/flat-example/org-deny-policy.tf
@@ -1,0 +1,6 @@
+resource "cloudsmith_package_deny_policy" "left_pad_policy" {
+    name                    = "Deny left-pad"
+    description             = "Deny left-pad versions greater than 1.1.2"
+    package_query           = "format:npm AND name:left-pad AND version:>1.1.2"
+    namespace               = data.cloudsmith_organization.org-demo.slug
+}

--- a/examples/flat-example/provider.tf
+++ b/examples/flat-example/provider.tf
@@ -1,0 +1,11 @@
+terraform {
+    required_providers {
+        cloudsmith = {
+          source = "cloudsmith-io/cloudsmith"
+        }
+    }
+}
+
+provider "cloudsmith" {
+  api_key = var.api_key
+}

--- a/examples/iterative-example/README.md
+++ b/examples/iterative-example/README.md
@@ -1,0 +1,20 @@
+# Terraform iterative structure example
+
+This terraform example project will setup 3 repositories using a loop-based approach for instances where each repository
+shares many attributes with the others, but changes slightly based on their individual needs.
+
+* Creates a Development, Staging and Production repository
+  * Disables User entitlements. The default entitlement token can then be disabled so that authentication can only be done via API keys!
+* Creates an individual CI service account for each repository which gets write access
+  * Configures Github OIDC for authenticating as the service accounts (see our documentation [here](https://help.cloudsmith.io/docs/setup-cloudsmith-to-authenticate-with-oidc-in-github-actions) for how to configure that on the Github side)
+* Creates a Developers team which gets write permission on the Development repository
+* Configures DockerHub and Chainguard upstreams on each repository
+* Configures a Vulnerablity policy that blocks high severity vulnerabilities.
+* Configures a license policy that blocks AGPL licensed packages. 
+
+## Usage
+
+To get started, supply your API key and org name in `global-variables.tf` file.
+Run `terraform init` and then run `terraform apply` to execute the plan.
+
+Configuration can be done in the `terraform.tfvars` file.

--- a/examples/iterative-example/global-variables.tf
+++ b/examples/iterative-example/global-variables.tf
@@ -1,0 +1,46 @@
+data "cloudsmith_organization" "cloudsmith-org" {
+  slug = "YOUR-ORG-NAME"
+}
+
+variable "api_key" {
+  type    = string
+  default = "YOUR-API-KEY"
+}
+
+variable "default_storage_region" {
+  type    = string
+  default = "us-ohio"
+}
+
+variable "chainguard_api_user" {
+    type    = string
+    default = "YOUR-CHAINGUARD-API-USER"
+}
+
+variable "chainguard_api_secret" {
+    type    = string
+    default = "YOUR-CHAINGUARD-API-SECRET"
+}
+
+variable "repositories" {
+  type = map(object({
+    add_developers = optional(bool)
+    oidc_claims = optional(map(string))
+  }))
+  description = "A map of repositories with their configurations."
+  default = {
+    "staging" = {
+      add_developers = false
+    },
+    "production" = {
+      add_developers = false
+    }
+  }
+}
+
+variable "oidc_claims" {
+    type  = map(string)
+    default = {
+      "repository" = "Owner/GitHubRepoName"
+    }
+}

--- a/examples/iterative-example/license-policy.tf
+++ b/examples/iterative-example/license-policy.tf
@@ -1,0 +1,7 @@
+resource "cloudsmith_license_policy" "agpl-policy" {
+    name                    = "Block AGPL"
+    description             = "Block AGPL licensed packages"
+    spdx_identifiers        = ["AGPL-1.0", "AGPL-1.0-only", "AGPL-1.0-or-later", "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later"]
+    on_violation_quarantine = true
+    organization            = data.cloudsmith_organization.cloudsmith-org.slug
+}

--- a/examples/iterative-example/oidc-config.tf
+++ b/examples/iterative-example/oidc-config.tf
@@ -1,0 +1,9 @@
+resource "cloudsmith_oidc" "org-oidc" {
+    for_each   = var.repositories
+    namespace  = data.cloudsmith_organization.cloudsmith-org.slug
+    name       = "Github OIDC - ${each.key}"
+    enabled    = true
+    provider_url = "https://token.actions.githubusercontent.com"
+    service_accounts = [cloudsmith_service.ci-service[each.key].slug]
+    claims = (each.value.oidc_claims != null) ? each.value.oidc_claims : var.oidc_claims
+}

--- a/examples/iterative-example/provider.tf
+++ b/examples/iterative-example/provider.tf
@@ -1,0 +1,11 @@
+terraform {
+    required_providers {
+        cloudsmith = {
+          source = "cloudsmith-io/cloudsmith"
+        }
+    }
+}
+
+provider "cloudsmith" {
+  api_key = var.api_key
+}

--- a/examples/iterative-example/repositories.tf
+++ b/examples/iterative-example/repositories.tf
@@ -1,0 +1,31 @@
+resource "cloudsmith_repository" "repositories" {
+  for_each                   =  var.repositories
+  description                = "${title(each.key)} repository"
+  name                       = "${each.key}"
+  namespace                  = data.cloudsmith_organization.cloudsmith-org.slug_perm
+  slug                       = "${each.key}"
+  repository_type            = "Private"
+  storage_region             = var.default_storage_region
+  user_entitlements_enabled  = false
+
+}
+
+resource "cloudsmith_repository_privileges" "repo-privs" {
+  for_each     = var.repositories
+  organization = data.cloudsmith_organization.cloudsmith-org.slug
+  repository   = cloudsmith_repository.repositories[each.key].slug
+
+  # if you're using a service account to provision, be sure to include it as an Admin here!
+  service {
+    privilege = "Write"
+    slug      = cloudsmith_service.ci-service[each.key].slug
+  }
+
+  dynamic "team" {
+    for_each = each.value.add_developers == true ? [1] : []
+    content {
+      privilege = "Write"
+      slug      = cloudsmith_team.developers.slug
+    }
+  }
+}

--- a/examples/iterative-example/services.tf
+++ b/examples/iterative-example/services.tf
@@ -1,0 +1,5 @@
+resource "cloudsmith_service" "ci-service" {
+  for_each     = var.repositories
+  name         = "${lower(each.key)}-ci-service"
+  organization = data.cloudsmith_organization.cloudsmith-org.slug
+}

--- a/examples/iterative-example/teams.tf
+++ b/examples/iterative-example/teams.tf
@@ -1,0 +1,4 @@
+resource "cloudsmith_team" "developers" {
+  organization = data.cloudsmith_organization.cloudsmith-org.slug_perm
+  name         = "Developers"
+}

--- a/examples/iterative-example/terraform.tfvars
+++ b/examples/iterative-example/terraform.tfvars
@@ -1,0 +1,14 @@
+repositories = {
+  "development": {
+    "add_developers": true
+  },
+  "staging": {
+    "add_developers": false
+  },
+  "production": {
+    "add_developers": false
+    "oidc_claims": {
+      "repository" = "Owner/ProductionGithubRepoName"
+    }
+  }
+}

--- a/examples/iterative-example/upstreams.tf
+++ b/examples/iterative-example/upstreams.tf
@@ -1,0 +1,39 @@
+# Chainguard public repositories, no authentication, affix /chainguard/ to URL when pulling.
+resource "cloudsmith_repository_upstream" "cgr-public" {
+  for_each      = var.repositories
+  name          = "cgr-public"
+  namespace     = data.cloudsmith_organization.cloudsmith-org.slug_perm
+  repository    = cloudsmith_repository.repositories[each.key].slug_perm
+  is_active     = true
+  upstream_type = "docker"
+  upstream_url  = "https://cgr.dev"
+  mode          = "Cache and Proxy"
+  priority      = 2
+}
+
+# Chainguard private repositories, uses authentication, affix /<your-chainguard-id>/ to URL when pulling.
+resource "cloudsmith_repository_upstream" "cgr-private" {
+  for_each      = var.repositories
+  name          = "cgr-private"
+  namespace     = data.cloudsmith_organization.cloudsmith-org.slug_perm
+  repository    = cloudsmith_repository.repositories[each.key].slug_perm
+  is_active     = true
+  upstream_type = "docker"
+  upstream_url  = "https://cgr.dev"
+  mode          = "Cache and Proxy"
+  auth_mode     = "Username and Password"
+  auth_username = var.chainguard_api_user
+  auth_secret   = var.chainguard_api_secret
+  priority      = 2
+}
+
+resource "cloudsmith_repository_upstream" "dockerhub" {
+  for_each      = var.repositories
+  name          = "dockerhub"
+  namespace     = data.cloudsmith_organization.cloudsmith-org.slug_perm
+  repository    = cloudsmith_repository.repositories[each.key].slug_perm
+  upstream_type = "docker"
+  upstream_url  = "https://index.docker.io"
+  mode          = "Cache and Proxy"
+  priority      = 1
+}

--- a/examples/iterative-example/vulnerability-policy.tf
+++ b/examples/iterative-example/vulnerability-policy.tf
@@ -1,0 +1,9 @@
+resource "cloudsmith_vulnerability_policy" "container-policy-test" {
+  name                    = "Container policy"
+  description             = "Block high severity issues in docker images"
+  min_severity            = "High"
+  on_violation_quarantine = true
+  allow_unknown_severity  = true
+  package_query_string    = "format:docker"
+  organization            = data.cloudsmith_organization.cloudsmith-org.slug
+}


### PR DESCRIPTION
Added in a `provider.tf` to the flat-example so that it is immediately runnable after modifying the `global-variables.tf` with an organization name and API key. Also added an example module for the package deny policy resource.

Provided an example project creating many similar repositories using `for_each` and dynamically updating resources based off of a `terraform.tfvars` configuration.