### PR TITLE
CENG-272: Update service resource docs

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -16,13 +16,13 @@ data "cloudsmith_organization" "my_org" {
 }
 
 resource "cloudsmith_team" "my_team" {
-	organization = data.cloudsmith_organization.my_org.slug_perm
+	organization = data.cloudsmith_organization.my_org.slug
 	name         = "My Team"
 }
 
 resource "cloudsmith_service" "my_service" {
 	name         = "My Service"
-	organization = data.cloudsmith_organization.my_org.slug_perm
+	organization = data.cloudsmith_organization.my_org.slug
 
 	team {
 		slug = cloudsmith_team.my_team.slug


### PR DESCRIPTION
Fixing [issue 74](https://github.com/cloudsmith-io/terraform-provider-cloudsmith/issues/74). 

* Service account referenced `slug_perm` in examples whilst the API only allows `slug` for the service endpoint, this PR changes that example to correct use of `slug`.