### PR TITLE
Chore(Update workflow permissions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     steps:
       -
         name: Checkout


### PR DESCRIPTION
The release workflow now requires `permissions` to be passed in order to interact with the repository contents.