### PR TITLE
CENG-305: Remove NorCal from docs

### DIFF
--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -280,7 +280,9 @@ func resourceRepository() *schema.Resource {
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 			if d.HasChange("storage_region") && d.Id() != "" {
-				d.SetNewComputed("storage_region")
+				if err := d.SetNewComputed("storage_region"); err != nil {
+					return fmt.Errorf("error setting storage_region to computed: %s", err)
+				}
 				return fmt.Errorf("warning: updating the 'storage_region' on an existing repository is currently unsupported via terraform, please update the region manually via the UI")
 			}
 			return nil

--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -278,15 +278,7 @@ func resourceRepository() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: importRepository,
 		},
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-			if d.HasChange("storage_region") && d.Id() != "" {
-				if err := d.SetNewComputed("storage_region"); err != nil {
-					return fmt.Errorf("error setting storage_region to computed: %s", err)
-				}
-				return fmt.Errorf("warning: updating the 'storage_region' on an existing repository is currently unsupported via terraform, please update the region manually via the UI")
-			}
-			return nil
-		},
+
 		Schema: map[string]*schema.Schema{
 			"cdn_url": {
 				Type:        schema.TypeString,
@@ -563,11 +555,8 @@ func resourceRepository() *schema.Resource {
 					"United States (us-oregon), Ohio, United States (us-ohio), Dublin, Ireland (ie-dublin)",
 				Optional:     true,
 				Computed:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"au-sydney", "sg-singapore", "ca-montreal", "de-frankfurt", "us-oregon", "us-ohio", "ie-dublin"}, false),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// Suppress diff if the resource is already created
-					return d.Id() != ""
-				},
 			},
 			"strict_npm_validation": {
 				Type: schema.TypeBool,

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -53,7 +53,6 @@ resource "cloudsmith_repository" "my_repository" {
 * `slug` - (Optional) The slug identifies the repository in URIs.
 * `storage_region` - (Optional) The Cloudsmith region in which package files are stored.
   * `default` - Default Region
-  * `us-norcal` - Northern California, United States
   * `au-sydney` - Sydney, Australia
   * `sg-singapore` - Singapore
   * `ca-montreal` - Montreal, Canada


### PR DESCRIPTION
* Removed North California from `region_type` as this region has been [deprecated](https://changelog.cloudsmith.com/en/deprecating-the-northern-california-storage-region?user_id=996da31c-0dfb-4f58-99ed-35d3e5276e0b). 