### PR TITLE
CENG-333: Update repo docs

### DIFF
--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -415,7 +415,7 @@ func resourceRepository() *schema.Resource {
 				Type:         schema.TypeString,
 				Description:  "A descriptive name for the repository.",
 				Required:     true,
-				ValidateFunc: validation.All(validation.StringIsNotEmpty, validateNoSpaces),
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"namespace": {
 				Type:         schema.TypeString,

--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -558,11 +558,11 @@ func resourceRepository() *schema.Resource {
 				Description: "The Cloudsmith region in which package files are stored." +
 					"Supported regions include: Sydney, Australia (au-sydney)," +
 					"Singapore (sg-singapore), Montreal, Canada (ca-montreal), Frankfurt, Germany (de-frankfurt), Oregon," +
-					"United States (us-oregon), Ohio, United States (us-ohio), Dublin, Ireland (ie-dublin)",
+					"United States (us-oregon), Ohio, United States (us-ohio), Dublin, Ireland (ie-dublin) (default)",
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"au-sydney", "sg-singapore", "ca-montreal", "de-frankfurt", "us-oregon", "us-ohio", "ie-dublin"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"au-sydney", "sg-singapore", "ca-montreal", "de-frankfurt", "us-oregon", "us-ohio", "ie-dublin", "default"}, false),
 			},
 			"strict_npm_validation": {
 				Type: schema.TypeBool,

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -17,7 +17,7 @@ data "cloudsmith_organization" "my_organization" {
 
 resource "cloudsmith_repository" "my_repository" {
     description = "A certifiably-awesome private package repository"
-    name        = "My Repository"
+    name        = "My-Repository"
     namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
     slug        = "my-repository"
 }
@@ -36,7 +36,7 @@ resource "cloudsmith_repository" "my_repository" {
 * `index_files` - (Optional) If set to `true`, files contained in packages will be indexed, which increase the synchronisation time required for packages. Note that it is recommended you keep this enabled unless the synchronisation time is significantly impacted.
 * `move_own` - (Optional) If set to `true`, users can move any of their own packages that they have uploaded, assuming that they still have write privilege for the repository. This takes precedence over privileges configured in the 'Access Controls' section of the repository, and any inherited from the org.
 * `move_packages` - (Optional) This defines the minimum level of privilege required for a user to move packages. Unless the package was uploaded by that user, in which the permission may be overridden by the user-specific move setting. Valid values include `Admin` and `Write`.
-* `name` - (Required) A descriptive name for the repository.
+* `name` - (Required) A descriptive name for the repository. Whitespaces are not allowed.
 * `namespace` - (Required) Namespace (or organization) to which this repository belongs.
 * `proxy_npmjs` - (Optional) If set to `true`, Npm packages that are not in the repository when requested by clients will automatically be proxied from the public npmjs.org registry. If there is at least one version for a package, others will not be proxied.
 * `proxy_pypi` - (Optional) If set to `true`, Python packages that are not in the repository when requested by clients will automatically be proxied from the public pypi.python.org registry. If there is at least one version for a package, others will not be proxied.

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -17,7 +17,7 @@ data "cloudsmith_organization" "my_organization" {
 
 resource "cloudsmith_repository" "my_repository" {
     description = "A certifiably-awesome private package repository"
-    name        = "My-Repository"
+    name        = "My Repository"
     namespace   = "${data.cloudsmith_organization.my_organization.slug_perm}"
     slug        = "my-repository"
 }
@@ -36,7 +36,7 @@ resource "cloudsmith_repository" "my_repository" {
 * `index_files` - (Optional) If set to `true`, files contained in packages will be indexed, which increase the synchronisation time required for packages. Note that it is recommended you keep this enabled unless the synchronisation time is significantly impacted.
 * `move_own` - (Optional) If set to `true`, users can move any of their own packages that they have uploaded, assuming that they still have write privilege for the repository. This takes precedence over privileges configured in the 'Access Controls' section of the repository, and any inherited from the org.
 * `move_packages` - (Optional) This defines the minimum level of privilege required for a user to move packages. Unless the package was uploaded by that user, in which the permission may be overridden by the user-specific move setting. Valid values include `Admin` and `Write`.
-* `name` - (Required) A descriptive name for the repository. Whitespaces are not allowed.
+* `name` - (Required) A descriptive visual name for the repository.
 * `namespace` - (Required) Namespace (or organization) to which this repository belongs.
 * `proxy_npmjs` - (Optional) If set to `true`, Npm packages that are not in the repository when requested by clients will automatically be proxied from the public npmjs.org registry. If there is at least one version for a package, others will not be proxied.
 * `proxy_pypi` - (Optional) If set to `true`, Python packages that are not in the repository when requested by clients will automatically be proxied from the public pypi.python.org registry. If there is at least one version for a package, others will not be proxied.


### PR DESCRIPTION
* Update repo docs to reflect `name` behaviour around whitespaces
* Update repo docs example - removed whitespace
* Added back `default` region to validation function in repository resource