### PR TITLE
CENG-338: Add composer to upstream resource

### DIFF
--- a/cloudsmith/resource_repository_upstream.go
+++ b/cloudsmith/resource_repository_upstream.go
@@ -14,18 +14,19 @@ import (
 
 // upstream types
 const (
-	Cran   = "cran"
-	Dart   = "dart"
-	Deb    = "deb"
-	Docker = "docker"
-	Helm   = "helm"
-	Maven  = "maven"
-	Npm    = "npm"
-	NuGet  = "nuget"
-	Python = "python"
-	Rpm    = "rpm"
-	Ruby   = "ruby"
-	Swift  = "swift"
+	Composer = "composer"
+	Cran     = "cran"
+	Dart     = "dart"
+	Deb      = "deb"
+	Docker   = "docker"
+	Helm     = "helm"
+	Maven    = "maven"
+	Npm      = "npm"
+	NuGet    = "nuget"
+	Python   = "python"
+	Rpm      = "rpm"
+	Ruby     = "ruby"
+	Swift    = "swift"
 )
 
 // tf state prop names
@@ -62,6 +63,7 @@ var (
 		"Cache Only",
 	}
 	upstreamTypes = []string{
+		Composer,
 		Cran,
 		Dart,
 		Deb,
@@ -137,6 +139,24 @@ func resourceRepositoryUpstreamCreate(d *schema.ResourceData, m interface{}) err
 	var err error
 
 	switch upstreamType {
+	case Composer:
+		req := pc.APIClient.ReposApi.ReposUpstreamComposerCreate(pc.Auth, namespace, repository)
+		req = req.Data(cloudsmith.ComposerUpstreamRequest{
+			AuthMode:     authMode,
+			AuthSecret:   authSecret,
+			AuthUsername: authUsername,
+			ExtraHeader1: extraHeader1,
+			ExtraHeader2: extraHeader2,
+			ExtraValue1:  extraValue1,
+			ExtraValue2:  extraValue2,
+			IsActive:     isActive,
+			Mode:         mode,
+			Name:         name,
+			Priority:     priority,
+			UpstreamUrl:  upstreamUrl,
+			VerifySsl:    verifySsl,
+		})
+		upstream, resp, err = pc.APIClient.ReposApi.ReposUpstreamComposerCreateExecute(req)
 	case Cran:
 		req := pc.APIClient.ReposApi.ReposUpstreamCranCreate(pc.Auth, namespace, repository)
 		req = req.Data(cloudsmith.CranUpstreamRequest{
@@ -401,6 +421,9 @@ func getUpstream(d *schema.ResourceData, m interface{}) (Upstream, *http.Respons
 	var upstream Upstream
 
 	switch upstreamType {
+	case Composer:
+		req := pc.APIClient.ReposApi.ReposUpstreamComposerRead(pc.Auth, namespace, repository, d.Id())
+		upstream, resp, err = pc.APIClient.ReposApi.ReposUpstreamComposerReadExecute(req)
 	case Cran:
 		req := pc.APIClient.ReposApi.ReposUpstreamCranRead(pc.Auth, namespace, repository, d.Id())
 		upstream, resp, err = pc.APIClient.ReposApi.ReposUpstreamCranReadExecute(req)
@@ -521,6 +544,24 @@ func resourceRepositoryUpstreamUpdate(d *schema.ResourceData, m interface{}) err
 	var err error
 
 	switch upstreamType {
+	case Composer:
+		req := pc.APIClient.ReposApi.ReposUpstreamComposerUpdate(pc.Auth, namespace, repository, slugPerm)
+		req = req.Data(cloudsmith.ComposerUpstreamRequest{
+			AuthMode:     authMode,
+			AuthSecret:   authSecret,
+			AuthUsername: authUsername,
+			ExtraHeader1: extraHeader1,
+			ExtraHeader2: extraHeader2,
+			ExtraValue1:  extraValue1,
+			ExtraValue2:  extraValue2,
+			IsActive:     isActive,
+			Mode:         mode,
+			Name:         name,
+			Priority:     priority,
+			UpstreamUrl:  upstreamUrl,
+			VerifySsl:    verifySsl,
+		})
+		upstream, _, err = pc.APIClient.ReposApi.ReposUpstreamComposerUpdateExecute(req)
 	case Cran:
 		req := pc.APIClient.ReposApi.ReposUpstreamCranUpdate(pc.Auth, namespace, repository, slugPerm)
 		req = req.Data(cloudsmith.CranUpstreamRequest{
@@ -779,6 +820,9 @@ func resourceRepositoryUpstreamDelete(d *schema.ResourceData, m interface{}) err
 	var err error
 
 	switch upstreamType {
+	case Composer:
+		req := pc.APIClient.ReposApi.ReposUpstreamComposerDelete(pc.Auth, namespace, repository, d.Id())
+		_, err = pc.APIClient.ReposApi.ReposUpstreamComposerDeleteExecute(req)
 	case Cran:
 		req := pc.APIClient.ReposApi.ReposUpstreamCranDelete(pc.Auth, namespace, repository, d.Id())
 		_, err = pc.APIClient.ReposApi.ReposUpstreamCranDeleteExecute(req)

--- a/docs/resources/repository_upstream.md
+++ b/docs/resources/repository_upstream.md
@@ -27,6 +27,18 @@ resource "cloudsmith_repository" "my_repository" {
 
 ...minimal configuration for various upstream types might be added as per the following examples for popular package registries.
 
+### Composer
+
+```hcl
+resource "cloudsmith_repository_upstream" "packagist" {
+    name          = "Packagist"
+    namespace     = "${data.cloudsmith_organization.my_organization.slug_perm}"
+    repository    = "${resource.cloudsmith_repository.my_repository.slug_perm}"
+    upstream_type = "composer"
+    upstream_url  = "https://packagist.org"
+}
+```
+
 ### Cran
 
 ```hcl
@@ -201,7 +213,7 @@ The following arguments are supported:
 |       `priority`        |    N     |    number    |                                                           N/A                                                           |                                                                      Upstream sources are selected for resolving requests by sequential order (1..n), followed by creation date.                                                                      |
 |      `repository`       |    Y     |    string    |                                                           N/A                                                           |                                                                                                     The Repository to which the upstream belongs.                                                                                                     |
 | `upstream_distribution` |    N     |    string    |                                                           N/A                                                           |                                    Used only in conjunction with an `upstream_type` of `"deb"` to declare the [distribution](https://wiki.debian.org/DebianRepository/Format#Overview) to fetch from the upstream.                                    |
-|     `upstream_type`     |    Y     |    string    | `"dart"`<br>`"deb"`<br>`"docker"`<br>`"helm"`<br>`"maven"`<br>`"npm"`<br>`"nuget"`<br>`"python"`<br>`"rpm"`<br>`"ruby"` |                                                                                                                 The type of Upstream.                                                                                                                 |
+|     `upstream_type`     |    Y     |    string    | `"composer"`<br>`"cran"`<br>`"dart"`<br>`"deb"`<br>`"docker"`<br>`"helm"`<br>`"maven"`<br>`"npm"`<br>`"nuget"`<br>`"python"`<br>`"rpm"`<br>`"ruby"`<br>`"swift"` | The type of Upstream. |
 |     `upstream_url`      |    Y     |    string    |                                                           N/A                                                           |                                                    The URL for this upstream source. This must be a fully qualified URL including any path elements required to reach the root of the repository. The URL cannot end with a trailing slash.                                                     |
 |      `verify_ssl`       |    N     |     bool     |                                                           N/A                                                           | If enabled, SSL certificates are verified when requests are made to this upstream. It's recommended to leave this enabled for all public sources to help mitigate Man-In-The-Middle (MITM) attacks. Please note this only applies to HTTPS upstreams. |
 


### PR DESCRIPTION
### Summary

- **Added**: Composer resource to upstream list  
  [Cloudsmith Composer Upstream Documentation](https://help.cloudsmith.io/reference/repos_upstream_composer_create)

- **Added**: Unit tests for Composer upstream functionality

- **Updated**: Documentation for Composer usage and setup
