### PR TITLE
fix constant diff in cloudsmith_manage_team

### DIFF
--- a/cloudsmith/resource_manage_team.go
+++ b/cloudsmith/resource_manage_team.go
@@ -30,9 +30,11 @@ func resourceManageTeamAdd(d *schema.ResourceData, m interface{}) error {
 	organization := requiredString(d, "organization")
 	teamName := requiredString(d, "team_name")
 
-	teamMembers := d.Get("members").([]interface{})
-	teamMembersList := make([]cloudsmith.OrganizationTeamMembership, len(teamMembers))
-	for i, v := range teamMembers {
+	// Fetching members from the Set, converting to a list
+	teamMembersSet := d.Get("members").(*schema.Set).List()
+	teamMembersList := make([]cloudsmith.OrganizationTeamMembership, len(teamMembersSet))
+
+	for i, v := range teamMembersSet {
 		teamMember := v.(map[string]interface{})
 		teamMembersList[i] = cloudsmith.OrganizationTeamMembership{
 			Role: teamMember["role"].(string),
@@ -63,9 +65,11 @@ func resourceManageTeamUpdateRemove(d *schema.ResourceData, m interface{}) error
 	organization := requiredString(d, "organization")
 	teamName := requiredString(d, "team_name")
 
-	teamMembers := d.Get("members").([]interface{})
-	teamMembersList := make([]cloudsmith.OrganizationTeamMembership, len(teamMembers))
-	for i, v := range teamMembers {
+	// Fetching members from the Set, converting to a list
+	teamMembersSet := d.Get("members").(*schema.Set).List()
+	teamMembersList := make([]cloudsmith.OrganizationTeamMembership, len(teamMembersSet))
+
+	for i, v := range teamMembersSet {
 		teamMember := v.(map[string]interface{})
 		teamMembersList[i] = cloudsmith.OrganizationTeamMembership{
 			Role: teamMember["role"].(string),
@@ -117,9 +121,11 @@ func resourceManageTeamRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	// Setting the values into the resource data
 	d.Set("organization", organization)
 	d.Set("team_name", teamName)
 	d.Set("members", members)
+
 	// Set the ID to the organization and team name, no slug returned from the API
 	d.SetId(fmt.Sprintf("%s.%s", organization, teamName))
 
@@ -147,7 +153,7 @@ func resourceManageTeam() *schema.Resource {
 				Required: true,
 			},
 			"members": {
-				Type: schema.TypeList,
+				Type: schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"role": {

--- a/examples/flat-example/org-deny-policy.tf
+++ b/examples/flat-example/org-deny-policy.tf
@@ -1,6 +1,6 @@
 resource "cloudsmith_package_deny_policy" "left_pad_policy" {
-    name                    = "Deny left-pad"
-    description             = "Deny left-pad versions greater than 1.1.2"
-    package_query           = "format:npm AND name:left-pad AND version:>1.1.2"
-    namespace               = data.cloudsmith_organization.org-demo.slug
+  name          = "Deny left-pad"
+  description   = "Deny left-pad versions greater than 1.1.2"
+  package_query = "format:npm AND name:left-pad AND version:>1.1.2"
+  namespace     = data.cloudsmith_organization.org-demo.slug
 }

--- a/examples/flat-example/org-license-policy.tf
+++ b/examples/flat-example/org-license-policy.tf
@@ -1,17 +1,17 @@
 resource "cloudsmith_license_policy" "apache-python-policy" {
-    name                    = "Example License Policy"
-    description             = "Apache 2 License Policy for Python packages"
-    spdx_identifiers        = ["Apache-2.0"]
-    on_violation_quarantine = true
-    package_query_string    = "format:python AND downloads:>50"
-    organization            = data.cloudsmith_organization.org-demo.slug
+  name                    = "Example License Policy"
+  description             = "Apache 2 License Policy for Python packages"
+  spdx_identifiers        = ["Apache-2.0"]
+  on_violation_quarantine = true
+  package_query_string    = "format:python AND downloads:>50"
+  organization            = data.cloudsmith_organization.org-demo.slug
 }
 
 resource "cloudsmith_license_policy" "mit-npm-policy" {
-    name                    = "Example License Policy"
-    description             = "MIT License Policy for Python packages"
-    spdx_identifiers        = ["MIT"]
-    on_violation_quarantine = true
-    package_query_string    = "format:npm"
-    organization            = data.cloudsmith_organization.org-demo.slug
+  name                    = "Example License Policy"
+  description             = "MIT License Policy for Python packages"
+  spdx_identifiers        = ["MIT"]
+  on_violation_quarantine = true
+  package_query_string    = "format:npm"
+  organization            = data.cloudsmith_organization.org-demo.slug
 }

--- a/examples/flat-example/org-oidc-config.tf
+++ b/examples/flat-example/org-oidc-config.tf
@@ -1,10 +1,10 @@
 resource "cloudsmith_oidc" "devops-oidc" {
-    namespace  = data.cloudsmith_organization.org-demo.slug
-    name       = "OIDC-DEMO"
-    enabled    = true
-    provider_url = "https://token.actions.githubusercontent.com"
-    service_accounts = [cloudsmith_service.production-service.slug]
-    claims = {
-        "repository" = "Owner/GitHubRepoName"
-    }
+  namespace        = data.cloudsmith_organization.org-demo.slug
+  name             = "OIDC-DEMO"
+  enabled          = true
+  provider_url     = "https://token.actions.githubusercontent.com"
+  service_accounts = [cloudsmith_service.production-service.slug]
+  claims = {
+    "repository" = "Owner/GitHubRepoName"
+  }
 }

--- a/examples/flat-example/org-saml-group.tf
+++ b/examples/flat-example/org-saml-group.tf
@@ -1,15 +1,15 @@
 resource "cloudsmith_saml" "owners_mapping" {
   organization = data.cloudsmith_organization.org-demo.slug
-  idp_key = "administrators"
-  idp_value = "administrators"
-  role = "Manager"
-  team = "owners"
+  idp_key      = "administrators"
+  idp_value    = "administrators"
+  role         = "Manager"
+  team         = "owners"
 }
 
 resource "cloudsmith_saml" "developers_mapping" {
   organization = data.cloudsmith_organization.org-demo.slug
-  idp_key = "interns"
-  idp_value = "interns"
-  role = "Member"
-  team = resource.cloudsmith_team.interns.slug
+  idp_key      = "interns"
+  idp_value    = "interns"
+  role         = "Member"
+  team         = resource.cloudsmith_team.interns.slug
 }

--- a/examples/flat-example/provider.tf
+++ b/examples/flat-example/provider.tf
@@ -1,9 +1,9 @@
 terraform {
-    required_providers {
-        cloudsmith = {
-          source = "cloudsmith-io/cloudsmith"
-        }
+  required_providers {
+    cloudsmith = {
+      source = "cloudsmith-io/cloudsmith"
     }
+  }
 }
 
 provider "cloudsmith" {

--- a/examples/flat-example/repo-devops.tf
+++ b/examples/flat-example/repo-devops.tf
@@ -27,7 +27,7 @@ resource "cloudsmith_repository_privileges" "devops-privs" {
 }
 
 resource "cloudsmith_repository_geo_ip_rules" "devops-geoip" {
-  repository = cloudsmith_repository.devops.slug
-  namespace = data.cloudsmith_organization.org-demo.slug
+  repository         = cloudsmith_repository.devops.slug
+  namespace          = data.cloudsmith_organization.org-demo.slug
   country_code_allow = var.geopip_allow_countries
 }

--- a/examples/iterative-example/global-variables.tf
+++ b/examples/iterative-example/global-variables.tf
@@ -13,19 +13,19 @@ variable "default_storage_region" {
 }
 
 variable "chainguard_api_user" {
-    type    = string
-    default = "YOUR-CHAINGUARD-API-USER"
+  type    = string
+  default = "YOUR-CHAINGUARD-API-USER"
 }
 
 variable "chainguard_api_secret" {
-    type    = string
-    default = "YOUR-CHAINGUARD-API-SECRET"
+  type    = string
+  default = "YOUR-CHAINGUARD-API-SECRET"
 }
 
 variable "repositories" {
   type = map(object({
     add_developers = optional(bool)
-    oidc_claims = optional(map(string))
+    oidc_claims    = optional(map(string))
   }))
   description = "A map of repositories with their configurations."
   default = {
@@ -39,8 +39,8 @@ variable "repositories" {
 }
 
 variable "oidc_claims" {
-    type  = map(string)
-    default = {
-      "repository" = "Owner/GitHubRepoName"
-    }
+  type = map(string)
+  default = {
+    "repository" = "Owner/GitHubRepoName"
+  }
 }

--- a/examples/iterative-example/license-policy.tf
+++ b/examples/iterative-example/license-policy.tf
@@ -1,7 +1,7 @@
 resource "cloudsmith_license_policy" "agpl-policy" {
-    name                    = "Block AGPL"
-    description             = "Block AGPL licensed packages"
-    spdx_identifiers        = ["AGPL-1.0", "AGPL-1.0-only", "AGPL-1.0-or-later", "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later"]
-    on_violation_quarantine = true
-    organization            = data.cloudsmith_organization.cloudsmith-org.slug
+  name                    = "Block AGPL"
+  description             = "Block AGPL licensed packages"
+  spdx_identifiers        = ["AGPL-1.0", "AGPL-1.0-only", "AGPL-1.0-or-later", "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later"]
+  on_violation_quarantine = true
+  organization            = data.cloudsmith_organization.cloudsmith-org.slug
 }

--- a/examples/iterative-example/oidc-config.tf
+++ b/examples/iterative-example/oidc-config.tf
@@ -1,9 +1,9 @@
 resource "cloudsmith_oidc" "org-oidc" {
-    for_each   = var.repositories
-    namespace  = data.cloudsmith_organization.cloudsmith-org.slug
-    name       = "Github OIDC - ${each.key}"
-    enabled    = true
-    provider_url = "https://token.actions.githubusercontent.com"
-    service_accounts = [cloudsmith_service.ci-service[each.key].slug]
-    claims = (each.value.oidc_claims != null) ? each.value.oidc_claims : var.oidc_claims
+  for_each         = var.repositories
+  namespace        = data.cloudsmith_organization.cloudsmith-org.slug
+  name             = "Github OIDC - ${each.key}"
+  enabled          = true
+  provider_url     = "https://token.actions.githubusercontent.com"
+  service_accounts = [cloudsmith_service.ci-service[each.key].slug]
+  claims           = (each.value.oidc_claims != null) ? each.value.oidc_claims : var.oidc_claims
 }

--- a/examples/iterative-example/provider.tf
+++ b/examples/iterative-example/provider.tf
@@ -1,9 +1,9 @@
 terraform {
-    required_providers {
-        cloudsmith = {
-          source = "cloudsmith-io/cloudsmith"
-        }
+  required_providers {
+    cloudsmith = {
+      source = "cloudsmith-io/cloudsmith"
     }
+  }
 }
 
 provider "cloudsmith" {

--- a/examples/iterative-example/repositories.tf
+++ b/examples/iterative-example/repositories.tf
@@ -1,12 +1,12 @@
 resource "cloudsmith_repository" "repositories" {
-  for_each                   =  var.repositories
-  description                = "${title(each.key)} repository"
-  name                       = "${each.key}"
-  namespace                  = data.cloudsmith_organization.cloudsmith-org.slug_perm
-  slug                       = "${each.key}"
-  repository_type            = "Private"
-  storage_region             = var.default_storage_region
-  user_entitlements_enabled  = false
+  for_each                  = var.repositories
+  description               = "${title(each.key)} repository"
+  name                      = each.key
+  namespace                 = data.cloudsmith_organization.cloudsmith-org.slug_perm
+  slug                      = each.key
+  repository_type           = "Private"
+  storage_region            = var.default_storage_region
+  user_entitlements_enabled = false
 
 }
 

--- a/examples/iterative-example/terraform.tfvars
+++ b/examples/iterative-example/terraform.tfvars
@@ -1,13 +1,13 @@
 repositories = {
-  "development": {
-    "add_developers": true
+  "development" : {
+    "add_developers" : true
   },
-  "staging": {
-    "add_developers": false
+  "staging" : {
+    "add_developers" : false
   },
-  "production": {
-    "add_developers": false
-    "oidc_claims": {
+  "production" : {
+    "add_developers" : false
+    "oidc_claims" : {
       "repository" = "Owner/ProductionGithubRepoName"
     }
   }


### PR DESCRIPTION
Fixes https://github.com/cloudsmith-io/terraform-provider-cloudsmith/issues/126

The only real change is to the ```cloudsmith/resource_manage_team.go``` file.

This alters the ```members``` to a schema of ```TypeSet``` rather than ```TypeList``` which allows terraform to ignore the order of the sorted members.

I tested this by running it against my Cloudsmith account, and all the relevant diffs were gone.

I also did multiple adding/deleting/updating of users into various teams, and terraform/Cloudsmith behaved correctly each time.

The ```examples``` files were updated as I run a ```terraform fmt``` pre-commit git hook, and so the formatting is now correct.

If this approved/merged, then could a new release be released, as this constant diff is really clouding our plans.

## Update

Looks like some of the GHA tests failed:

```provider_test.go:32: CLOUDSMITH_API_KEY must be set for acceptance tests```

```Secret `SLACK_WEBHOOK` is missing. Please add it to this action for proper execution```

But not much I can do about that.
