### PR TITLE
fix(no-ticket): fix  null pointer issues on saml resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ main.tf
 terraform.tfstate
 terraform.tfstate.backup
 terraform-provider-cloudsmith
+dist
+

--- a/cloudsmith/resource_saml_auth.go
+++ b/cloudsmith/resource_saml_auth.go
@@ -171,7 +171,7 @@ func setSAMLAuthFields(d *schema.ResourceData, organization string, samlAuth *cl
 
 	// Handle URL metadata with null handling
 	url, hasURL := samlAuth.GetSamlMetadataUrlOk()
-	if !hasURL || *url == "" {
+	if !hasURL || url == nil || *url == "" {
 		return setField("saml_metadata_url", nil)
 	}
 	return setField("saml_metadata_url", url)
@@ -185,7 +185,7 @@ func generateSAMLAuthID(organization string, samlAuth *cloudsmith.OrganizationSA
 		data += fmt.Sprintf("-%t", samlAuth.GetSamlAuthEnabled())
 		data += fmt.Sprintf("-%t", samlAuth.GetSamlAuthEnforced())
 
-		if url, hasURL := samlAuth.GetSamlMetadataUrlOk(); hasURL {
+		if url, hasURL := samlAuth.GetSamlMetadataUrlOk(); url != nil && hasURL {
 			data += fmt.Sprintf("-%s", *url)
 		}
 


### PR DESCRIPTION
When attempting to import a SAML auth provider where no URL was specified I faced a nil pointer issue. Looking at the code this makes sense.

This commit is to fix that by doing null checks.