### PR TITLE
No-ticket: Update the cert and key auth to be more robust

### DIFF
--- a/cloudsmith/resource_repository_upstream.go
+++ b/cloudsmith/resource_repository_upstream.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -117,33 +116,38 @@ func importUpstream(_ context.Context, d *schema.ResourceData, _ interface{}) ([
 	return []*schema.ResourceData{d}, nil
 }
 
-// readCertificateFiles reads the certificate and key files for mTLS authentication
-// Returns pointers to the certificate and key contents, and any error encountered
+// readCertificateContent reads and validates certificate content
+func readCertificateContent(content string) error {
+	content = strings.TrimSpace(content)
+	if !strings.HasPrefix(content, "-----BEGIN CERTIFICATE-----") {
+		return fmt.Errorf("invalid certificate format: must be a PEM encoded certificate")
+	}
+	return nil
+}
+
+// readPrivateKeyContent reads and validates private key content
+func readPrivateKeyContent(content string) error {
+	content = strings.TrimSpace(content)
+	if !strings.HasPrefix(content, "-----BEGIN") || !strings.Contains(content, "PRIVATE KEY-----") {
+		return fmt.Errorf("invalid private key format: must be a PEM encoded private key")
+	}
+	return nil
+}
+
+// readCertificateFiles reads the certificate files and returns their contents
 func readCertificateFiles(d *schema.ResourceData) (cert, key *string, err error) {
-	if certPath := optionalString(d, AuthCertificate); certPath != nil {
-		certContent, err := os.ReadFile(*certPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error reading auth certificate file: %w", err)
+	if certContent := optionalString(d, AuthCertificate); certContent != nil {
+		if err := readCertificateContent(*certContent); err != nil {
+			return nil, nil, err
 		}
-		// Remove any trailing whitespace and ensure proper PEM format
-		certStr := strings.TrimSpace(string(certContent))
-		if !strings.HasPrefix(certStr, "-----BEGIN CERTIFICATE-----") {
-			return nil, nil, fmt.Errorf("invalid certificate format: must be a PEM encoded certificate")
-		}
-		cert = &certStr
+		cert = certContent
 	}
 
-	if certKeyPath := optionalString(d, AuthCertificateKey); certKeyPath != nil {
-		certKeyContent, err := os.ReadFile(*certKeyPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error reading auth certificate key file: %w", err)
+	if keyContent := optionalString(d, AuthCertificateKey); keyContent != nil {
+		if err := readPrivateKeyContent(*keyContent); err != nil {
+			return nil, nil, err
 		}
-		// Remove any trailing whitespace and ensure proper PEM format
-		certKeyStr := strings.TrimSpace(string(certKeyContent))
-		if !strings.HasPrefix(certKeyStr, "-----BEGIN") || !strings.Contains(certKeyStr, "PRIVATE KEY-----") {
-			return nil, nil, fmt.Errorf("invalid private key format: must be a PEM encoded private key")
-		}
-		key = &certKeyStr
+		key = keyContent
 	}
 
 	// Both certificate and key must be provided together
@@ -283,9 +287,6 @@ func resourceRepositoryUpstreamCreate(d *schema.ResourceData, m interface{}) err
 			VerifySsl:          verifySsl,
 		})
 		upstream, resp, err = pc.APIClient.ReposApi.ReposUpstreamDockerCreateExecute(req)
-		if err != nil {
-			return err
-		}
 	case Helm:
 		req := pc.APIClient.ReposApi.ReposUpstreamHelmCreate(pc.Auth, namespace, repository)
 		req = req.Data(cloudsmith.HelmUpstreamRequest{
@@ -521,7 +522,6 @@ func getUpstream(d *schema.ResourceData, m interface{}) (Upstream, *http.Respons
 }
 
 func resourceRepositoryUpstreamRead(d *schema.ResourceData, m interface{}) error {
-
 	upstream, resp, err := getUpstream(d, m)
 
 	if err != nil {
@@ -700,9 +700,6 @@ func resourceRepositoryUpstreamUpdate(d *schema.ResourceData, m interface{}) err
 			VerifySsl:          verifySsl,
 		})
 		upstream, _, err = pc.APIClient.ReposApi.ReposUpstreamDockerUpdateExecute(req)
-		if err != nil {
-			return err
-		}
 	case Helm:
 		req := pc.APIClient.ReposApi.ReposUpstreamHelmUpdate(pc.Auth, namespace, repository, slugPerm)
 		req = req.Data(cloudsmith.HelmUpstreamRequest{
@@ -989,15 +986,19 @@ func resourceRepositoryUpstream() *schema.Resource {
 			},
 			AuthCertificate: {
 				Type:         schema.TypeString,
-				Description:  "Path to the X.509 Certificate file to use for mTLS authentication against the upstream (Docker only)",
+				Description:  "The X.509 Certificate (PEM encoded) to use for mTLS authentication against the upstream (Docker only). Use the file() function to read this from a file.",
 				Optional:     true,
+				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
+				ForceNew:     true,
 			},
 			AuthCertificateKey: {
 				Type:         schema.TypeString,
-				Description:  "Path to the Certificate key file to use for mTLS authentication against the upstream (Docker only)",
+				Description:  "The Certificate private key (PEM encoded) to use for mTLS authentication against the upstream (Docker only). Use the file() function to read this from a file.",
 				Optional:     true,
+				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
+				ForceNew:     true,
 			},
 			Component: {
 				Type:         schema.TypeString,

--- a/cloudsmith/resource_repository_upstream_test.go
+++ b/cloudsmith/resource_repository_upstream_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io"
 	"math/big"
 	"net/http"
 	"os"
@@ -1362,7 +1361,7 @@ func testAccRepositoryUpstreamCheckDestroy(resourceName string) resource.TestChe
 			req := pc.APIClient.ReposApi.ReposUpstreamSwiftRead(pc.Auth, namespace, repository, slugPerm)
 			_, resp, err = pc.APIClient.ReposApi.ReposUpstreamSwiftReadExecute(req)
 		default:
-			err = fmt.Errorf("invalid upstream_type: '%s'", upstreamType)
+			return fmt.Errorf("invalid upstream_type: '%s'", upstreamType)
 		}
 
 		if err != nil && !is404(resp) {
@@ -1370,9 +1369,9 @@ func testAccRepositoryUpstreamCheckDestroy(resourceName string) resource.TestChe
 		} else if is200(resp) {
 			return fmt.Errorf("unable to verify upstream deletion: still exists: %s", resourceName)
 		}
-		defer func(Body io.ReadCloser) {
-			_ = Body.Close()
-		}(resp.Body)
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
 
 		return nil
 	}

--- a/docs/resources/repository_upstream.md
+++ b/docs/resources/repository_upstream.md
@@ -96,7 +96,7 @@ resource "cloudsmith_repository_upstream" "docker_hub" {
 }
 ```
 
-> **Note:** Certificate and Key authentication is only supported for Docker, we recommend using a unique filename for the certificate and key files to avoid conflicts.
+> **Note:** Certificate and Key authentication is only supported for Docker.
 
 ```hcl
 resource "cloudsmith_repository_upstream" "other_docker_upstream" {
@@ -106,8 +106,8 @@ resource "cloudsmith_repository_upstream" "other_docker_upstream" {
     upstream_type = "docker"
     upstream_url  = "https://other.docker.io"
     auth_mode     = "Certificate and Key"
-    auth_certificate = "/path/to/certificate_date.crt"
-    auth_certificate_key = "/path/to/certificate_date.key"
+    auth_certificate = file("${path.module}/certs/client.crt")
+    auth_certificate_key = file("${path.module}/certs/client.key")
 }
 ```
 
@@ -218,8 +218,8 @@ The following arguments are supported:
 |       `auth_mode`       |    N     |    string    |                                   `"None"`<br>`"Username and Password"`<br>`"Token"`<br>`"Certificate and Key"`                                    |                                                                                              The authentication mode to use when accessing the upstream.                                                                                              |
 |      `auth_secret`      |    N     |    string    |                                                           N/A                                                           |                                                   Used in conjunction with an `auth_mode` of `"Username and Password"` or `"Token"` to hold the password or token used when accessing the upstream.                                                   |
 |     `auth_username`     |    N     |    string    |                                                           N/A                                                           |                                                          Used only in conjunction with an `auth_mode` of `"Username and Password"` to declare the username used when accessing the upstream.                                                          |
-|    `auth_certificate`   |    N     |    string    |                                                           N/A                                                           |                                                          Used only in conjunction with an `auth_mode` of `"Certificate and Key"` to specify the path to the certificate file for mTLS authentication.                                                          |
-|  `auth_certificate_key` |    N     |    string    |                                                           N/A                                                           |                                                          Used only in conjunction with an `auth_mode` of `"Certificate and Key"` to specify the path to the certificate key file for mTLS authentication.                                                          |
+|    `auth_certificate`   |    N     |    string    |                                                           N/A                                                           |                                                          Used only in conjunction with an `auth_mode` of `"Certificate and Key"` to provide the PEM-encoded certificate content for mTLS authentication. Use with the `file()` function.                                                          |
+|  `auth_certificate_key` |    N     |    string    |                                                           N/A                                                           |                                                          Used only in conjunction with an `auth_mode` of `"Certificate and Key"` to provide the PEM-encoded private key content for mTLS authentication. Use with the `file()` function.                                                          |
 |       `component`       |    N     |    string    |                                                           N/A                                                           |                                    Used only in conjunction with an `upstream_type` of `"deb"` to declare the [component](https://wiki.debian.org/DebianRepository/Format#Components) to fetch from the upstream.                                     |
 |    `distro_version`     |    N     |    string    |                                                           N/A                                                           |                                             Used only in conjunction with an `upstream_type` of `"rpm"` to declare the distribution/version that packages found on this upstream will be associated with.                                             |
 |    `distro_versions`    |    N     | list<string> |                                                           N/A                                                           |                                       Used only in conjunction with an `upstream_type` of `"deb"` to declare the array of distributions/versions that packages found on this upstream will be associated with.                                        |


### PR DESCRIPTION
The most recent release requires the user to pass a path to the cert/key for upstream authentication, this change utilises the `file()` function provided by terraform which improves this process. 