### PR TITLE
Original work by @RoseSecurity in #192

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: cloudsmith.Provider,
+		ProviderAddr: "registry.terraform.io/cloudsmith-io/cloudsmith",
 		Debug:        debugMode,
 	})
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/cloudsmith-io/terraform-provider-cloudsmith/cloudsmith"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: cloudsmith.Provider,
+		Debug:        debugMode,
 	})
 }


### PR DESCRIPTION
# Description

This updates the `main.go` entrypoint for the Terraform Cloudsmith provider to add support for running the provider in debug mode and to explicitly set the provider address. These changes improve the development workflow and compatibility with Terraform's provider registry.

---

* Added a `--debug` flag to enable running the provider with debugger support (such as Delve), making it easier to troubleshoot and develop the provider locally.
* Explicitly set the `ProviderAddr` to `"registry.terraform.io/cloudsmith-io/cloudsmith"` to ensure correct provider identification and compatibility with Terraform's registry.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tests
- [ ] Other (please describe)
