### PR TITLE
refactor(eng-12343): add central pagination utility across all list

### DIFF
--- a/cloudsmith/data_entitlement.go
+++ b/cloudsmith/data_entitlement.go
@@ -1,6 +1,7 @@
 package cloudsmith
 
 import (
+	"net/http"
 	"strconv"
 	"time"
 
@@ -8,58 +9,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func retrieveEntitlmentTokenListPage(pc *providerConfig, namespace string, repository string, page int64, pageSize int64, showToken bool, query string, activeToken bool) ([]cloudsmith.RepositoryToken, int64, error) {
-	req := pc.APIClient.EntitlementsApi.EntitlementsList(pc.Auth, namespace, repository)
-	req = req.Page(page)
-	req = req.PageSize(pageSize)
-	req = req.ShowTokens(showToken)
-	req = req.Query(query)
-	req = req.Active(activeToken)
-
-	tokensPage, httpResponse, err := pc.APIClient.EntitlementsApi.EntitlementsListExecute(req)
-	if err != nil {
-		return nil, 0, err
+func retrieveEntitlmentListPages(pc *providerConfig, namespace, repository, query string, showToken, activeToken bool) ([]cloudsmith.RepositoryToken, error) {
+	exec := func(page, ps int64) ([]cloudsmith.RepositoryToken, *http.Response, error) {
+		req := pc.APIClient.EntitlementsApi.EntitlementsList(pc.Auth, namespace, repository).
+			Page(page).
+			PageSize(ps).
+			ShowTokens(showToken).
+			Query(query).
+			Active(activeToken)
+		return pc.APIClient.EntitlementsApi.EntitlementsListExecute(req)
 	}
-	pageTotal, err := strconv.ParseInt(httpResponse.Header.Get("X-Pagination-Pagetotal"), 10, 64)
-	if err != nil {
-		return nil, 0, err
-	}
-	return tokensPage, pageTotal, nil
-}
-
-func retrieveEntitlmentListPages(pc *providerConfig, namespace string, repository string, query string, pageSize int64, pageCount int64, showToken bool, activeToken bool) ([]cloudsmith.RepositoryToken, error) {
-
-	var pageCurrentCount int64 = 1
-
-	// A negative or zero count is assumed to mean retrieve the largest size page
-	tokensList := []cloudsmith.RepositoryToken{}
-	if pageSize == -1 || pageSize == 0 {
-		pageSize = 100
-	}
-
-	// If no count is supplied assmumed to mean retrieve all pages
-	// we have to retreive a page to get this count
-	if pageCount == -1 || pageCount == 0 {
-		var tokensPage []cloudsmith.RepositoryToken
-		var err error
-		tokensPage, pageCount, err = retrieveEntitlmentTokenListPage(pc, namespace, repository, 1, pageSize, showToken, query, activeToken)
-		if err != nil {
-			return nil, err
-		}
-		tokensList = append(tokensList, tokensPage...)
-		pageCurrentCount++
-	}
-
-	for pageCurrentCount <= pageCount {
-		tokensPage, _, err := retrieveEntitlmentTokenListPage(pc, namespace, repository, pageCount, pageSize, showToken, query, activeToken)
-		if err != nil {
-			return nil, err
-		}
-		tokensList = append(tokensList, tokensPage...)
-		pageCurrentCount++
-	}
-
-	return tokensList, nil
+	return PaginateAllHTTP[cloudsmith.RepositoryToken](exec, PaginationOptions{})
 }
 
 func flattenEntitlementToken(token []cloudsmith.RepositoryToken) []interface{} {
@@ -119,9 +79,7 @@ func dataSourceEntitlementRead(d *schema.ResourceData, m interface{}) error {
 	showTokenVal := optionalBool(d, "show_token")
 	activeTokenVal := optionalBool(d, "active_token")
 
-	var pageCount, pageSize int64 = -1, -1
-
-	entitlementList, err := retrieveEntitlmentListPages(pc, namespace, repository, query, pageSize, pageCount, *showTokenVal, *activeTokenVal)
+	entitlementList, err := retrieveEntitlmentListPages(pc, namespace, repository, query, *showTokenVal, *activeTokenVal)
 	if err != nil {
 		return err
 	}

--- a/cloudsmith/data_entitlement.go
+++ b/cloudsmith/data_entitlement.go
@@ -9,19 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func retrieveEntitlmentListPages(pc *providerConfig, namespace, repository, query string, showToken, activeToken bool) ([]cloudsmith.RepositoryToken, error) {
-	exec := func(page, ps int64) ([]cloudsmith.RepositoryToken, *http.Response, error) {
-		req := pc.APIClient.EntitlementsApi.EntitlementsList(pc.Auth, namespace, repository).
-			Page(page).
-			PageSize(ps).
-			ShowTokens(showToken).
-			Query(query).
-			Active(activeToken)
-		return pc.APIClient.EntitlementsApi.EntitlementsListExecute(req)
-	}
-	return PaginateAllHTTP[cloudsmith.RepositoryToken](exec, PaginationOptions{})
-}
-
 func flattenEntitlementToken(token []cloudsmith.RepositoryToken) []interface{} {
 	tokenList := make([]interface{}, len(token))
 
@@ -76,10 +63,19 @@ func dataSourceEntitlementRead(d *schema.ResourceData, m interface{}) error {
 	namespace := requiredString(d, "namespace")
 	repository := requiredString(d, "repository")
 	query := buildQueryString(d.Get("query").(*schema.Set))
-	showTokenVal := optionalBool(d, "show_token")
-	activeTokenVal := optionalBool(d, "active_token")
+	showTokenVal := *optionalBool(d, "show_token")
+	activeTokenVal := *optionalBool(d, "active_token")
 
-	entitlementList, err := retrieveEntitlmentListPages(pc, namespace, repository, query, *showTokenVal, *activeTokenVal)
+	exec := func(page, ps int64) ([]cloudsmith.RepositoryToken, *http.Response, error) {
+		req := pc.APIClient.EntitlementsApi.EntitlementsList(pc.Auth, namespace, repository).
+			Page(page).
+			PageSize(ps).
+			ShowTokens(showTokenVal).
+			Query(query).
+			Active(activeTokenVal)
+		return pc.APIClient.EntitlementsApi.EntitlementsListExecute(req)
+	}
+	entitlementList, err := PaginateAllHTTP[cloudsmith.RepositoryToken](exec, PaginationOptions{})
 	if err != nil {
 		return err
 	}

--- a/cloudsmith/data_source_organization_members.go
+++ b/cloudsmith/data_source_organization_members.go
@@ -2,6 +2,7 @@ package cloudsmith
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -10,71 +11,27 @@ import (
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 )
 
-func retrieveOrgMemeberListPage(pc *providerConfig, organization string, isActive bool, pageSize int64, pageCount int64) ([]cloudsmith.OrganizationMembership, int64, error) {
-	req := pc.APIClient.OrgsApi.OrgsMembersList(pc.Auth, organization)
-	req = req.Page(pageCount)
-	req = req.PageSize(pageSize)
-	req = req.IsActive(isActive)
-
-	membersPage, httpResponse, err := pc.APIClient.OrgsApi.OrgsMembersListExecute(req)
-	if err != nil {
-		return nil, 0, err
+func retrieveOrgMemeberListPages(pc *providerConfig, organization string, isActive bool) ([]cloudsmith.OrganizationMembership, error) {
+	exec := func(page, ps int64) ([]cloudsmith.OrganizationMembership, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsMembersList(pc.Auth, organization).
+			Page(page).
+			PageSize(ps).
+			IsActive(isActive)
+		return pc.APIClient.OrgsApi.OrgsMembersListExecute(req)
 	}
-	pageTotal, err := strconv.ParseInt(httpResponse.Header.Get("X-Pagination-Pagetotal"), 10, 64)
-	if err != nil {
-		return nil, 0, err
-	}
-	return membersPage, pageTotal, nil
+	return PaginateAllHTTP[cloudsmith.OrganizationMembership](exec, PaginationOptions{})
 }
 
-func retrieveOrgMemeberListPages(pc *providerConfig, organization string, isActive bool, pageSize int64, pageCount int64) ([]cloudsmith.OrganizationMembership, error) {
-
-	var pageCurrentCount int64 = 1
-
-	// A negative or zero count is assumed to mean retrieve the largest size page
-	membersList := []cloudsmith.OrganizationMembership{}
-	if pageSize == -1 || pageSize == 0 {
-		pageSize = 100
-	}
-
-	// If no count is supplied assmumed to mean retrieve all pages
-	// we have to retreive a page to get this count
-	if pageCount == -1 || pageCount == 0 {
-		var membersPage []cloudsmith.OrganizationMembership
-		var err error
-		membersPage, pageCount, err = retrieveOrgMemeberListPage(pc, organization, isActive, pageSize, 1)
-		if err != nil {
-			return nil, err
-		}
-		membersList = append(membersList, membersPage...)
-		pageCurrentCount++
-	}
-
-	for pageCurrentCount <= pageCount {
-		membersPage, _, err := retrieveOrgMemeberListPage(pc, organization, isActive, pageSize, pageCount)
-		if err != nil {
-			return nil, err
-		}
-		membersList = append(membersList, membersPage...)
-		pageCurrentCount++
-	}
-
-	return membersList, nil
-}
-
-// dataSourceOrganizationMembersListRead reads the organization members from the API and filters them based on the provided query.
 func dataSourceOrganizationMembersListRead(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
 	namespace := d.Get("namespace").(string)
 	isActive := d.Get("is_active").(bool)
 
-	// Retrieve all organization members
-	members, err := retrieveOrgMemeberListPages(pc, namespace, isActive, -1, -1)
+	members, err := retrieveOrgMemeberListPages(pc, namespace, isActive)
 	if err != nil {
 		return fmt.Errorf("error retrieving organization members: %s", err)
 	}
 
-	// Map the filtered members to the schema
 	if err := d.Set("members", flattenOrganizationMembers(members)); err != nil {
 		return fmt.Errorf("error setting members: %s", err)
 	}
@@ -83,7 +40,6 @@ func dataSourceOrganizationMembersListRead(d *schema.ResourceData, m interface{}
 	return nil
 }
 
-// flattenOrganizationMembers maps organization members to a format suitable for the schema.
 func flattenOrganizationMembers(members []cloudsmith.OrganizationMembership) []interface{} {
 	var out []interface{}
 	for _, member := range members {

--- a/cloudsmith/data_source_organization_members.go
+++ b/cloudsmith/data_source_organization_members.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 )
 
-func retrieveOrgMemeberListPages(pc *providerConfig, organization string, isActive bool) ([]cloudsmith.OrganizationMembership, error) {
+func retrieveOrgMemberListPages(pc *providerConfig, organization string, isActive bool) ([]cloudsmith.OrganizationMembership, error) {
 	exec := func(page, ps int64) ([]cloudsmith.OrganizationMembership, *http.Response, error) {
 		req := pc.APIClient.OrgsApi.OrgsMembersList(pc.Auth, organization).
 			Page(page).
@@ -27,7 +27,7 @@ func dataSourceOrganizationMembersListRead(d *schema.ResourceData, m interface{}
 	namespace := d.Get("namespace").(string)
 	isActive := d.Get("is_active").(bool)
 
-	members, err := retrieveOrgMemeberListPages(pc, namespace, isActive)
+	members, err := retrieveOrgMemberListPages(pc, namespace, isActive)
 	if err != nil {
 		return fmt.Errorf("error retrieving organization members: %s", err)
 	}

--- a/cloudsmith/data_source_organization_members.go
+++ b/cloudsmith/data_source_organization_members.go
@@ -11,23 +11,19 @@ import (
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 )
 
-func retrieveOrgMemberListPages(pc *providerConfig, organization string, isActive bool) ([]cloudsmith.OrganizationMembership, error) {
-	exec := func(page, ps int64) ([]cloudsmith.OrganizationMembership, *http.Response, error) {
-		req := pc.APIClient.OrgsApi.OrgsMembersList(pc.Auth, organization).
-			Page(page).
-			PageSize(ps).
-			IsActive(isActive)
-		return pc.APIClient.OrgsApi.OrgsMembersListExecute(req)
-	}
-	return PaginateAllHTTP[cloudsmith.OrganizationMembership](exec, PaginationOptions{})
-}
-
 func dataSourceOrganizationMembersListRead(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
 	namespace := d.Get("namespace").(string)
 	isActive := d.Get("is_active").(bool)
 
-	members, err := retrieveOrgMemberListPages(pc, namespace, isActive)
+	exec := func(page, ps int64) ([]cloudsmith.OrganizationMembership, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsMembersList(pc.Auth, namespace).
+			Page(page).
+			PageSize(ps).
+			IsActive(isActive)
+		return pc.APIClient.OrgsApi.OrgsMembersListExecute(req)
+	}
+	members, err := PaginateAllHTTP[cloudsmith.OrganizationMembership](exec, PaginationOptions{})
 	if err != nil {
 		return fmt.Errorf("error retrieving organization members: %s", err)
 	}

--- a/cloudsmith/data_source_package_list.go
+++ b/cloudsmith/data_source_package_list.go
@@ -13,23 +13,6 @@ import (
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 )
 
-func retrievePackageListPages(pc *providerConfig, namespace, repository, query string, mostRecent bool) ([]cloudsmith.Package, error) {
-	exec := func(page, ps int64) ([]cloudsmith.Package, *http.Response, error) {
-		req := pc.APIClient.PackagesApi.PackagesList(pc.Auth, namespace, repository).
-			Page(page).
-			PageSize(ps).
-			Query(query)
-		return pc.APIClient.PackagesApi.PackagesListExecute(req)
-	}
-
-	opts := PaginationOptions{}
-	if mostRecent {
-		opts.PageSize = 1
-		opts.MaxResults = 1
-	}
-	return PaginateAllHTTP[cloudsmith.Package](exec, opts)
-}
-
 func buildQueryString(set *schema.Set) string {
 	var query strings.Builder
 	for _, v := range set.List() {
@@ -47,7 +30,19 @@ func dataSourcePackageListRead(d *schema.ResourceData, m interface{}) error {
 	query := buildQueryString(d.Get("filters").(*schema.Set))
 	mostRecent := requiredBool(d, "most_recent")
 
-	packagesList, err := retrievePackageListPages(pc, namespace, repository, query, mostRecent)
+	exec := func(page, ps int64) ([]cloudsmith.Package, *http.Response, error) {
+		req := pc.APIClient.PackagesApi.PackagesList(pc.Auth, namespace, repository).
+			Page(page).
+			PageSize(ps).
+			Query(query)
+		return pc.APIClient.PackagesApi.PackagesListExecute(req)
+	}
+	opts := PaginationOptions{}
+	if mostRecent {
+		opts.PageSize = 1
+		opts.MaxResults = 1
+	}
+	packagesList, err := PaginateAllHTTP[cloudsmith.Package](exec, opts)
 	if err != nil {
 		return err
 	}

--- a/cloudsmith/data_source_package_list.go
+++ b/cloudsmith/data_source_package_list.go
@@ -2,6 +2,7 @@ package cloudsmith
 
 import (
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -12,56 +13,21 @@ import (
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 )
 
-func retrievePackageListPage(pc *providerConfig, namespace string, repository string, query string, pageSize int64, pageCount int64) ([]cloudsmith.Package, int64, error) {
-	req := pc.APIClient.PackagesApi.PackagesList(pc.Auth, namespace, repository)
-	req = req.Page(pageCount)
-	req = req.PageSize(pageSize)
-	req = req.Query(query)
-
-	packagesPage, httpResponse, err := pc.APIClient.PackagesApi.PackagesListExecute(req)
-	if err != nil {
-		return nil, 0, err
-	}
-	pageTotal, err := strconv.ParseInt(httpResponse.Header.Get("X-Pagination-Pagetotal"), 10, 64)
-	if err != nil {
-		return nil, 0, err
-	}
-	return packagesPage, pageTotal, nil
-}
-
-func retrievePackageListPages(pc *providerConfig, namespace string, repository string, query string, pageSize int64, pageCount int64) ([]cloudsmith.Package, error) {
-
-	var pageCurrentCount int64 = 1
-
-	// A negative or zero count is assumed to mean retrieve the largest size page
-	packagesList := []cloudsmith.Package{}
-	if pageSize == -1 || pageSize == 0 {
-		pageSize = 100
+func retrievePackageListPages(pc *providerConfig, namespace, repository, query string, mostRecent bool) ([]cloudsmith.Package, error) {
+	exec := func(page, ps int64) ([]cloudsmith.Package, *http.Response, error) {
+		req := pc.APIClient.PackagesApi.PackagesList(pc.Auth, namespace, repository).
+			Page(page).
+			PageSize(ps).
+			Query(query)
+		return pc.APIClient.PackagesApi.PackagesListExecute(req)
 	}
 
-	// If no count is supplied assmumed to mean retrieve all pages
-	// we have to retreive a page to get this count
-	if pageCount == -1 || pageCount == 0 {
-		var packagesPage []cloudsmith.Package
-		var err error
-		packagesPage, pageCount, err = retrievePackageListPage(pc, namespace, repository, query, pageSize, 1)
-		if err != nil {
-			return nil, err
-		}
-		packagesList = append(packagesList, packagesPage...)
-		pageCurrentCount++
+	opts := PaginationOptions{}
+	if mostRecent {
+		opts.PageSize = 1
+		opts.MaxResults = 1
 	}
-
-	for pageCurrentCount <= pageCount {
-		packagesPage, _, err := retrievePackageListPage(pc, namespace, repository, query, pageSize, pageCount)
-		if err != nil {
-			return nil, err
-		}
-		packagesList = append(packagesList, packagesPage...)
-		pageCurrentCount++
-
-	}
-	return packagesList, nil
+	return PaginateAllHTTP[cloudsmith.Package](exec, opts)
 }
 
 func buildQueryString(set *schema.Set) string {
@@ -81,12 +47,7 @@ func dataSourcePackageListRead(d *schema.ResourceData, m interface{}) error {
 	query := buildQueryString(d.Get("filters").(*schema.Set))
 	mostRecent := requiredBool(d, "most_recent")
 
-	var pageCount, pageSize int64 = -1, -1
-	if mostRecent {
-		pageCount = 1
-		pageSize = 1
-	}
-	packagesList, err := retrievePackageListPages(pc, namespace, repository, query, pageSize, pageCount)
+	packagesList, err := retrievePackageListPages(pc, namespace, repository, query, mostRecent)
 	if err != nil {
 		return err
 	}

--- a/cloudsmith/data_source_repository_connected_list.go
+++ b/cloudsmith/data_source_repository_connected_list.go
@@ -2,6 +2,7 @@ package cloudsmith
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -82,30 +83,18 @@ func dataSourceRepositoryConnectedListRead(d *schema.ResourceData, m interface{}
 }
 
 func retrieveAllConnectedRepositories(pc *providerConfig, namespace, repository string) ([]cloudsmith.ConnectedRepository, error) {
-	var all []cloudsmith.ConnectedRepository
-	var page int64 = 1
-	const pageSize int64 = 100
-
-	for {
-		req := pc.APIClient.ReposApi.ReposConnectedList(pc.Auth, namespace, repository)
-		req = req.Page(page)
-		req = req.PageSize(pageSize)
-
-		resp, _, err := pc.APIClient.ReposApi.ReposConnectedListExecute(req)
+	exec := func(page, ps int64) ([]cloudsmith.ConnectedRepository, *http.Response, error) {
+		req := pc.APIClient.ReposApi.ReposConnectedList(pc.Auth, namespace, repository).
+			Page(page).
+			PageSize(ps)
+		payload, httpResp, err := pc.APIClient.ReposApi.ReposConnectedListExecute(req)
 		if err != nil {
-			return nil, err
+			return nil, httpResp, err
 		}
-
-		results := resp.GetResults()
-		all = append(all, results...)
-
-		if int64(len(results)) < pageSize {
-			break
-		}
-		page++
+		return payload.GetResults(), httpResp, nil
 	}
 
-	return all, nil
+	return PaginateAllHTTP[cloudsmith.ConnectedRepository](exec, PaginationOptions{})
 }
 
 func flattenConnectedRepositories(items []cloudsmith.ConnectedRepository) []interface{} {

--- a/cloudsmith/data_source_repository_privileges.go
+++ b/cloudsmith/data_source_repository_privileges.go
@@ -74,31 +74,24 @@ func dataSourceRepositoryPrivileges() *schema.Resource {
 	}
 }
 
-// dataSourceRepositoryPrivilegesRead retrieves privileges information for the specified repository.
 func dataSourceRepositoryPrivilegesRead(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
 
 	organization := d.Get("organization").(string)
 	repository := d.Get("repository").(string)
 
-	req := pc.APIClient.ReposApi.ReposPrivilegesList(pc.Auth, organization, repository)
-	// TODO: add a proper loop here to ensure we always get all privs,
-	// regardless of how many are configured.
-	req = req.Page(1)
-	req = req.PageSize(1000)
-	privileges, resp, err := pc.APIClient.ReposApi.ReposPrivilegesListExecute(req)
+	all, notFound, err := retrieveRepositoryPrivilegePages(pc, organization, repository)
 	if err != nil {
-		if is404(resp) {
-			d.SetId("")
-			return nil
-		}
-
 		return err
 	}
+	if notFound {
+		d.SetId("")
+		return nil
+	}
 
-	d.Set("service", flattenRepositoryPrivilegeServices(privileges.GetPrivileges()))
-	d.Set("team", flattenRepositoryPrivilegeTeams(privileges.GetPrivileges()))
-	d.Set("user", flattenRepositoryPrivilegeUsers(privileges.GetPrivileges()))
+	d.Set("service", flattenRepositoryPrivilegeServices(all))
+	d.Set("team", flattenRepositoryPrivilegeTeams(all))
+	d.Set("user", flattenRepositoryPrivilegeUsers(all))
 
 	d.SetId(fmt.Sprintf("%s/%s", organization, repository))
 

--- a/cloudsmith/data_source_service_list.go
+++ b/cloudsmith/data_source_service_list.go
@@ -10,22 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func retrieveServiceListPages(pc *providerConfig, organization string, query, sort *string) ([]cloudsmith.Service, error) {
-	exec := func(page, ps int64) ([]cloudsmith.Service, *http.Response, error) {
-		req := pc.APIClient.OrgsApi.OrgsServicesList(pc.Auth, organization).
-			Page(page).
-			PageSize(ps)
-		if query != nil && *query != "" {
-			req = req.Query(*query)
-		}
-		if sort != nil && *sort != "" {
-			req = req.Sort(*sort)
-		}
-		return pc.APIClient.OrgsApi.OrgsServicesListExecute(req)
-	}
-	return PaginateAllHTTP[cloudsmith.Service](exec, PaginationOptions{})
-}
-
 func flattenServices(in []cloudsmith.Service) []interface{} {
 	out := make([]interface{}, len(in))
 	for i, s := range in {
@@ -72,7 +56,19 @@ func dataSourceServiceListRead(d *schema.ResourceData, m interface{}) error {
 		sortPtr = &ss
 	}
 
-	services, err := retrieveServiceListPages(pc, organization, queryPtr, sortPtr)
+	exec := func(page, ps int64) ([]cloudsmith.Service, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsServicesList(pc.Auth, organization).
+			Page(page).
+			PageSize(ps)
+		if queryPtr != nil && *queryPtr != "" {
+			req = req.Query(*queryPtr)
+		}
+		if sortPtr != nil && *sortPtr != "" {
+			req = req.Sort(*sortPtr)
+		}
+		return pc.APIClient.OrgsApi.OrgsServicesListExecute(req)
+	}
+	services, err := PaginateAllHTTP[cloudsmith.Service](exec, PaginationOptions{})
 	if err != nil {
 		return fmt.Errorf("error retrieving services for %s: %w", organization, err)
 	}

--- a/cloudsmith/data_source_service_list.go
+++ b/cloudsmith/data_source_service_list.go
@@ -2,6 +2,7 @@ package cloudsmith
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -9,57 +10,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// retrieveServiceListPage fetches a single page of services.
-func retrieveServiceListPage(pc *providerConfig, organization string, pageSize int64, page int64, query, sort *string) ([]cloudsmith.Service, int64, error) {
-	req := pc.APIClient.OrgsApi.OrgsServicesList(pc.Auth, organization)
-	req = req.Page(page)
-	req = req.PageSize(pageSize)
-	if query != nil && *query != "" {
-		req = req.Query(*query)
+func retrieveServiceListPages(pc *providerConfig, organization string, query, sort *string) ([]cloudsmith.Service, error) {
+	exec := func(page, ps int64) ([]cloudsmith.Service, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsServicesList(pc.Auth, organization).
+			Page(page).
+			PageSize(ps)
+		if query != nil && *query != "" {
+			req = req.Query(*query)
+		}
+		if sort != nil && *sort != "" {
+			req = req.Sort(*sort)
+		}
+		return pc.APIClient.OrgsApi.OrgsServicesListExecute(req)
 	}
-	if sort != nil && *sort != "" {
-		req = req.Sort(*sort)
-	}
-
-	servicesPage, httpResp, err := pc.APIClient.OrgsApi.OrgsServicesListExecute(req)
-	if err != nil {
-		return nil, 0, err
-	}
-	pageTotal, err := strconv.ParseInt(httpResp.Header.Get("X-Pagination-Pagetotal"), 10, 64)
-	if err != nil {
-		return nil, 0, err
-	}
-	return servicesPage, pageTotal, nil
+	return PaginateAllHTTP[cloudsmith.Service](exec, PaginationOptions{})
 }
 
-// retrieveServiceListPages retrieves all pages of services.
-func retrieveServiceListPages(pc *providerConfig, organization string, pageSize, pageCount int64, query, sort *string) ([]cloudsmith.Service, error) {
-	var current int64 = 1
-	services := []cloudsmith.Service{}
-	if pageSize <= 0 {
-		pageSize = 100
-	}
-	if pageCount <= 0 {
-		first, total, err := retrieveServiceListPage(pc, organization, pageSize, 1, query, sort)
-		if err != nil {
-			return nil, err
-		}
-		services = append(services, first...)
-		pageCount = total
-		current++
-	}
-	for current <= pageCount {
-		pageData, _, err := retrieveServiceListPage(pc, organization, pageSize, current, query, sort)
-		if err != nil {
-			return nil, err
-		}
-		services = append(services, pageData...)
-		current++
-	}
-	return services, nil
-}
-
-// flattenServices converts []Service into []interface{} for TF state.
 func flattenServices(in []cloudsmith.Service) []interface{} {
 	out := make([]interface{}, len(in))
 	for i, s := range in {
@@ -96,7 +62,6 @@ func dataSourceServiceListRead(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
 	organization := requiredString(d, "organization")
 
-	// Optional filtering/sorting arguments
 	var queryPtr, sortPtr *string
 	if v, ok := d.GetOk("query"); ok {
 		qs := v.(string)
@@ -107,8 +72,7 @@ func dataSourceServiceListRead(d *schema.ResourceData, m interface{}) error {
 		sortPtr = &ss
 	}
 
-	// Always iterate all pages (Terraform expectation).
-	services, err := retrieveServiceListPages(pc, organization, -1, -1, queryPtr, sortPtr)
+	services, err := retrieveServiceListPages(pc, organization, queryPtr, sortPtr)
 	if err != nil {
 		return fmt.Errorf("error retrieving services for %s: %w", organization, err)
 	}
@@ -117,7 +81,6 @@ func dataSourceServiceListRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("error setting services: %w", err)
 	}
 
-	// ephemeral ID
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 	return nil
 }

--- a/cloudsmith/data_source_teams.go
+++ b/cloudsmith/data_source_teams.go
@@ -2,6 +2,7 @@ package cloudsmith
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -9,58 +10,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// retrieveTeamListPage retrieves a single page of teams for an organization.
-func retrieveTeamListPage(pc *providerConfig, organization string, pageSize int64, page int64) ([]cloudsmith.OrganizationTeam, int64, error) {
-	req := pc.APIClient.OrgsApi.OrgsTeamsList(pc.Auth, organization)
-	req = req.Page(page)
-	req = req.PageSize(pageSize)
-
-	teamsPage, httpResponse, err := pc.APIClient.OrgsApi.OrgsTeamsListExecute(req)
-	if err != nil {
-		return nil, 0, err
+func retrieveTeamListPages(pc *providerConfig, organization string) ([]cloudsmith.OrganizationTeam, error) {
+	exec := func(page, ps int64) ([]cloudsmith.OrganizationTeam, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsTeamsList(pc.Auth, organization).
+			Page(page).
+			PageSize(ps)
+		return pc.APIClient.OrgsApi.OrgsTeamsListExecute(req)
 	}
-	pageTotal, err := strconv.ParseInt(httpResponse.Header.Get("X-Pagination-Pagetotal"), 10, 64)
-	if err != nil {
-		return nil, 0, err
-	}
-	return teamsPage, pageTotal, nil
+	return PaginateAllHTTP[cloudsmith.OrganizationTeam](exec, PaginationOptions{})
 }
 
-// retrieveTeamListPages retrieves all pages (or a single page if pageCount provided) of teams.
-func retrieveTeamListPages(pc *providerConfig, organization string, pageSize int64, pageCount int64) ([]cloudsmith.OrganizationTeam, error) {
-	var pageCurrent int64 = 1
-
-	// Default page size if none provided
-	teams := []cloudsmith.OrganizationTeam{}
-	if pageSize <= 0 {
-		pageSize = 100
-	}
-
-	// If no pageCount passed, discover total pages
-	if pageCount <= 0 {
-		var firstPage []cloudsmith.OrganizationTeam
-		var err error
-		firstPage, pageCount, err = retrieveTeamListPage(pc, organization, pageSize, 1)
-		if err != nil {
-			return nil, err
-		}
-		teams = append(teams, firstPage...)
-		pageCurrent++
-	}
-
-	for pageCurrent <= pageCount {
-		pageData, _, err := retrieveTeamListPage(pc, organization, pageSize, pageCurrent)
-		if err != nil {
-			return nil, err
-		}
-		teams = append(teams, pageData...)
-		pageCurrent++
-	}
-
-	return teams, nil
-}
-
-// flattenOrgTeams converts a slice of organization teams to terraform list representation.
 func flattenOrgTeams(in []cloudsmith.OrganizationTeam) []interface{} {
 	out := make([]interface{}, len(in))
 	for i, team := range in {
@@ -75,13 +34,12 @@ func flattenOrgTeams(in []cloudsmith.OrganizationTeam) []interface{} {
 	return out
 }
 
-// dataSourceTeamListRead reads all teams for an organization.
 func dataSourceTeamListRead(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
 
 	organization := requiredString(d, "organization")
 
-	teams, err := retrieveTeamListPages(pc, organization, -1, -1)
+	teams, err := retrieveTeamListPages(pc, organization)
 	if err != nil {
 		return fmt.Errorf("error retrieving teams for organization %s: %w", organization, err)
 	}
@@ -90,13 +48,11 @@ func dataSourceTeamListRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("error setting teams: %w", err)
 	}
 
-	// Use timestamp as ephemeral ID – list data source
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 
 	return nil
 }
 
-// dataSourceTeamList defines the schema for listing teams.
 func dataSourceTeamList() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceTeamListRead,

--- a/cloudsmith/data_source_teams.go
+++ b/cloudsmith/data_source_teams.go
@@ -10,16 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func retrieveTeamListPages(pc *providerConfig, organization string) ([]cloudsmith.OrganizationTeam, error) {
-	exec := func(page, ps int64) ([]cloudsmith.OrganizationTeam, *http.Response, error) {
-		req := pc.APIClient.OrgsApi.OrgsTeamsList(pc.Auth, organization).
-			Page(page).
-			PageSize(ps)
-		return pc.APIClient.OrgsApi.OrgsTeamsListExecute(req)
-	}
-	return PaginateAllHTTP[cloudsmith.OrganizationTeam](exec, PaginationOptions{})
-}
-
 func flattenOrgTeams(in []cloudsmith.OrganizationTeam) []interface{} {
 	out := make([]interface{}, len(in))
 	for i, team := range in {
@@ -39,7 +29,13 @@ func dataSourceTeamListRead(d *schema.ResourceData, m interface{}) error {
 
 	organization := requiredString(d, "organization")
 
-	teams, err := retrieveTeamListPages(pc, organization)
+	exec := func(page, ps int64) ([]cloudsmith.OrganizationTeam, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsTeamsList(pc.Auth, organization).
+			Page(page).
+			PageSize(ps)
+		return pc.APIClient.OrgsApi.OrgsTeamsListExecute(req)
+	}
+	teams, err := PaginateAllHTTP[cloudsmith.OrganizationTeam](exec, PaginationOptions{})
 	if err != nil {
 		return fmt.Errorf("error retrieving teams for organization %s: %w", organization, err)
 	}

--- a/cloudsmith/pagination.go
+++ b/cloudsmith/pagination.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	DefaultPageSize int64 = 100
-	DefaultMaxPages int64 = 650
 
 	paginationCountHeader     = "X-Pagination-Count"
 	paginationPageHeader      = "X-Pagination-Page"
@@ -16,10 +15,9 @@ const (
 	paginationPageSizeHeader  = "X-Pagination-PageSize"
 )
 
-// PaginationOptions controls page size and result caps.
+// PaginationOptions controls page size and optional result cap.
 type PaginationOptions struct {
 	PageSize   int64
-	MaxPages   int64
 	MaxResults int64
 }
 
@@ -29,48 +27,29 @@ type PageFetcher[T any] func(page, pageSize int64) (results []T, totalPages int6
 // PageExecutor matches the generated SDK's list Execute methods.
 type PageExecutor[T any] func(page, pageSize int64) (results []T, resp *http.Response, err error)
 
-// PaginateAll collects pages until MaxResults or the API-reported page total.
+// PaginateAll collects every page reported by the API, stopping early only when
+// MaxResults is reached. Iteration ends when the current page equals the
+// API-reported total page count (X-Pagination-PageTotal).
 func PaginateAll[T any](fetch PageFetcher[T], opts PaginationOptions) ([]T, error) {
 	pageSize := opts.PageSize
 	if pageSize <= 0 {
 		pageSize = DefaultPageSize
 	}
-	maxPages := opts.MaxPages
-	if maxPages <= 0 {
-		maxPages = DefaultMaxPages
-	}
 
 	var all []T
-	var totalPages int64
 	var page int64 = 1
 	for {
-		if page > maxPages {
-			return nil, fmt.Errorf(
-				"pagination exceeded MaxPages (%d); aborting to prevent runaway iteration",
-				maxPages,
-			)
-		}
-
-		results, tp, err := fetch(page, pageSize)
+		results, totalPages, err := fetch(page, pageSize)
 		if err != nil {
 			return nil, err
 		}
 		all = append(all, results...)
-		if tp < 0 {
-			return nil, fmt.Errorf("pagination returned invalid total page count %d", tp)
+		if totalPages < 0 {
+			return nil, fmt.Errorf("pagination returned invalid total page count %d", totalPages)
 		}
-		totalPages = tp
 
 		if opts.MaxResults > 0 && int64(len(all)) >= opts.MaxResults {
 			return all[:opts.MaxResults], nil
-		}
-
-		if totalPages > maxPages && (opts.MaxResults <= 0 || maxPages*pageSize < opts.MaxResults) {
-			return nil, fmt.Errorf(
-				"pagination requires %d pages, exceeding MaxPages (%d)",
-				totalPages,
-				maxPages,
-			)
 		}
 
 		if page >= totalPages {

--- a/cloudsmith/pagination.go
+++ b/cloudsmith/pagination.go
@@ -1,0 +1,134 @@
+package cloudsmith
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+const (
+	DefaultPageSize int64 = 100
+	DefaultMaxPages int64 = 650
+
+	paginationCountHeader     = "X-Pagination-Count"
+	paginationPageHeader      = "X-Pagination-Page"
+	paginationPageTotalHeader = "X-Pagination-PageTotal"
+	paginationPageSizeHeader  = "X-Pagination-PageSize"
+)
+
+// PaginationOptions controls page size and result caps.
+type PaginationOptions struct {
+	PageSize   int64
+	MaxPages   int64
+	MaxResults int64
+}
+
+// PageFetcher fetches one page and returns the API-reported total page count.
+type PageFetcher[T any] func(page, pageSize int64) (results []T, totalPages int64, err error)
+
+// PageExecutor matches the generated SDK's list Execute methods.
+type PageExecutor[T any] func(page, pageSize int64) (results []T, resp *http.Response, err error)
+
+// PaginateAll collects pages until MaxResults or the API-reported page total.
+func PaginateAll[T any](fetch PageFetcher[T], opts PaginationOptions) ([]T, error) {
+	pageSize := opts.PageSize
+	if pageSize <= 0 {
+		pageSize = DefaultPageSize
+	}
+	maxPages := opts.MaxPages
+	if maxPages <= 0 {
+		maxPages = DefaultMaxPages
+	}
+
+	var all []T
+	var totalPages int64
+	var page int64 = 1
+	for {
+		if page > maxPages {
+			return nil, fmt.Errorf(
+				"pagination exceeded MaxPages (%d); aborting to prevent runaway iteration",
+				maxPages,
+			)
+		}
+
+		results, tp, err := fetch(page, pageSize)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, results...)
+		if tp < 0 {
+			return nil, fmt.Errorf("pagination returned invalid total page count %d", tp)
+		}
+		totalPages = tp
+
+		if opts.MaxResults > 0 && int64(len(all)) >= opts.MaxResults {
+			return all[:opts.MaxResults], nil
+		}
+
+		if totalPages > maxPages && (opts.MaxResults <= 0 || maxPages*pageSize < opts.MaxResults) {
+			return nil, fmt.Errorf(
+				"pagination requires %d pages, exceeding MaxPages (%d)",
+				totalPages,
+				maxPages,
+			)
+		}
+
+		if page >= totalPages {
+			return all, nil
+		}
+
+		page++
+	}
+}
+
+// PaginateAllHTTP validates Cloudsmith pagination headers before paginating.
+func PaginateAllHTTP[T any](exec PageExecutor[T], opts PaginationOptions) ([]T, error) {
+	fetch := func(page, pageSize int64) ([]T, int64, error) {
+		results, resp, err := exec(page, pageSize)
+		if err != nil {
+			return nil, 0, err
+		}
+		total, err := parsePageTotal(resp)
+		if err != nil {
+			return nil, 0, err
+		}
+		return results, total, nil
+	}
+	return PaginateAll[T](fetch, opts)
+}
+
+// parsePageTotal validates the Cloudsmith pagination headers and returns PageTotal.
+func parsePageTotal(resp *http.Response) (int64, error) {
+	if resp == nil {
+		return 0, fmt.Errorf("missing HTTP response while parsing pagination headers")
+	}
+	if _, err := parseRequiredPaginationHeader(resp, paginationCountHeader); err != nil {
+		return 0, err
+	}
+	if _, err := parseRequiredPaginationHeader(resp, paginationPageHeader); err != nil {
+		return 0, err
+	}
+	total, err := parseRequiredPaginationHeader(resp, paginationPageTotalHeader)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := parseRequiredPaginationHeader(resp, paginationPageSizeHeader); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func parseRequiredPaginationHeader(resp *http.Response, name string) (int64, error) {
+	raw := resp.Header.Get(name)
+	if raw == "" {
+		return 0, fmt.Errorf("missing required pagination header %s", name)
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("parsing %s: value must be non-negative", name)
+	}
+	return n, nil
+}

--- a/cloudsmith/pagination.go
+++ b/cloudsmith/pagination.go
@@ -82,11 +82,16 @@ func PaginateAll[T any](fetch PageFetcher[T], opts PaginationOptions) ([]T, erro
 }
 
 // PaginateAllHTTP validates Cloudsmith pagination headers before paginating.
+// A 404 response is treated as an empty list so callers can short-circuit
+// "not found" without hitting header-parsing errors.
 func PaginateAllHTTP[T any](exec PageExecutor[T], opts PaginationOptions) ([]T, error) {
 	fetch := func(page, pageSize int64) ([]T, int64, error) {
 		results, resp, err := exec(page, pageSize)
 		if err != nil {
 			return nil, 0, err
+		}
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, 0, nil
 		}
 		total, err := parsePageTotal(resp)
 		if err != nil {

--- a/cloudsmith/pagination_test.go
+++ b/cloudsmith/pagination_test.go
@@ -61,22 +61,6 @@ func TestPaginateAll_SinglePageWithHeader(t *testing.T) {
 	}
 }
 
-func TestPaginateAll_HitMaxPages(t *testing.T) {
-	calls := 0
-	fetch := func(page, pageSize int64) ([]int64, int64, error) {
-		calls++
-		return makeItems((page-1)*pageSize, pageSize), 9999, nil
-	}
-
-	_, err := PaginateAll[int64](fetch, PaginationOptions{PageSize: 10, MaxPages: 3})
-	if err == nil {
-		t.Fatalf("expected MaxPages error, got nil")
-	}
-	if calls != 1 {
-		t.Fatalf("expected early MaxPages error after 1 call, got %d", calls)
-	}
-}
-
 func TestPaginateAll_HitMaxResults(t *testing.T) {
 	fetch := func(page, pageSize int64) ([]int64, int64, error) {
 		return makeItems((page-1)*pageSize, pageSize), 100, nil
@@ -94,7 +78,7 @@ func TestPaginateAll_HitMaxResults(t *testing.T) {
 	}
 }
 
-func TestPaginateAll_MaxResultsCanStopBeforeMaxPages(t *testing.T) {
+func TestPaginateAll_MaxResultsStopsEarly(t *testing.T) {
 	calls := 0
 	fetch := func(page, pageSize int64) ([]int64, int64, error) {
 		calls++
@@ -103,7 +87,6 @@ func TestPaginateAll_MaxResultsCanStopBeforeMaxPages(t *testing.T) {
 
 	got, err := PaginateAll[int64](fetch, PaginationOptions{
 		PageSize:   10,
-		MaxPages:   1,
 		MaxResults: 5,
 	})
 	if err != nil {

--- a/cloudsmith/pagination_test.go
+++ b/cloudsmith/pagination_test.go
@@ -1,0 +1,313 @@
+package cloudsmith
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// makeItems returns a slice of int identifiers [start, start+n).
+func makeItems(start, n int64) []int64 {
+	out := make([]int64, 0, n)
+	for i := int64(0); i < n; i++ {
+		out = append(out, start+i)
+	}
+	return out
+}
+
+func TestPaginateAll_MultiPageWithHeader(t *testing.T) {
+	calls := 0
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		calls++
+		switch page {
+		case 1:
+			return makeItems(0, pageSize), 3, nil
+		case 2:
+			return makeItems(pageSize, pageSize), 3, nil
+		case 3:
+			return makeItems(2*pageSize, pageSize), 3, nil
+		}
+		t.Fatalf("unexpected page %d", page)
+		return nil, 0, nil
+	}
+
+	got, err := PaginateAll[int64](fetch, PaginationOptions{PageSize: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 30 {
+		t.Fatalf("expected 30 results, got %d", len(got))
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 fetcher calls, got %d", calls)
+	}
+}
+
+func TestPaginateAll_SinglePageWithHeader(t *testing.T) {
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		if page != 1 {
+			t.Fatalf("expected only page 1, got %d", page)
+		}
+		return makeItems(0, 3), 1, nil
+	}
+
+	got, err := PaginateAll[int64](fetch, PaginationOptions{PageSize: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(got))
+	}
+}
+
+func TestPaginateAll_HitMaxPages(t *testing.T) {
+	calls := 0
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		calls++
+		return makeItems((page-1)*pageSize, pageSize), 9999, nil
+	}
+
+	_, err := PaginateAll[int64](fetch, PaginationOptions{PageSize: 10, MaxPages: 3})
+	if err == nil {
+		t.Fatalf("expected MaxPages error, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("expected early MaxPages error after 1 call, got %d", calls)
+	}
+}
+
+func TestPaginateAll_HitMaxResults(t *testing.T) {
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		return makeItems((page-1)*pageSize, pageSize), 100, nil
+	}
+
+	got, err := PaginateAll[int64](fetch, PaginationOptions{
+		PageSize:   10,
+		MaxResults: 25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if int64(len(got)) != 25 {
+		t.Fatalf("expected 25 results, got %d", len(got))
+	}
+}
+
+func TestPaginateAll_MaxResultsCanStopBeforeMaxPages(t *testing.T) {
+	calls := 0
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		calls++
+		return makeItems((page-1)*pageSize, pageSize), 9999, nil
+	}
+
+	got, err := PaginateAll[int64](fetch, PaginationOptions{
+		PageSize:   10,
+		MaxPages:   1,
+		MaxResults: 5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("expected 5 results, got %d", len(got))
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 fetcher call, got %d", calls)
+	}
+}
+
+func TestPaginateAll_FetcherErrorPropagates(t *testing.T) {
+	sentinel := errors.New("api boom")
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		return nil, 0, sentinel
+	}
+
+	_, err := PaginateAll[int64](fetch, PaginationOptions{PageSize: 10})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+func TestPaginateAll_DefaultsApplied(t *testing.T) {
+	var seenPageSize int64
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		seenPageSize = pageSize
+		return makeItems(0, 1), 1, nil
+	}
+
+	_, err := PaginateAll[int64](fetch, PaginationOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seenPageSize != DefaultPageSize {
+		t.Fatalf("expected default pageSize %d, got %d", DefaultPageSize, seenPageSize)
+	}
+}
+
+func TestPaginateAll_EmptyFirstPage(t *testing.T) {
+	calls := 0
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		calls++
+		return []int64{}, 0, nil
+	}
+
+	got, err := PaginateAll[int64](fetch, PaginationOptions{PageSize: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(got))
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 fetcher call, got %d", calls)
+	}
+}
+
+func TestPaginateAll_MaxResultsZeroMeansUnlimited(t *testing.T) {
+	fetch := func(page, pageSize int64) ([]int64, int64, error) {
+		switch page {
+		case 1:
+			return makeItems(0, pageSize), 2, nil
+		case 2:
+			return makeItems(pageSize, pageSize), 2, nil
+		}
+		t.Fatalf("unexpected page %d", page)
+		return nil, 0, nil
+	}
+
+	got, err := PaginateAll[int64](fetch, PaginationOptions{PageSize: 10, MaxResults: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 20 {
+		t.Fatalf("expected 20 results (no cap), got %d", len(got))
+	}
+}
+
+func TestParsePageTotal(t *testing.T) {
+	cases := []struct {
+		name   string
+		resp   *http.Response
+		want   int64
+		errSub string
+	}{
+		{name: "nil response", resp: nil, errSub: "missing HTTP response"},
+		{name: "missing count header", resp: paginationResponse("7", withoutHeader(paginationCountHeader)), errSub: "missing required pagination header X-Pagination-Count"},
+		{name: "missing page total header", resp: paginationResponse("7", withoutHeader(paginationPageTotalHeader)), errSub: "missing required pagination header X-Pagination-PageTotal"},
+		{name: "valid headers", resp: paginationResponse("7"), want: 7},
+		{name: "malformed page total header", resp: paginationResponse("not-a-number"), errSub: "parsing X-Pagination-PageTotal"},
+		{name: "negative page total header", resp: paginationResponse("-1"), errSub: "value must be non-negative"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePageTotal(tc.resp)
+			if tc.errSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errSub)
+				}
+				if !strings.Contains(err.Error(), tc.errSub) {
+					t.Fatalf("expected error containing %q, got %q", tc.errSub, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("want %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+func paginationResponse(pageTotal string, opts ...func(http.Header)) *http.Response {
+	header := http.Header{}
+	header.Set(paginationCountHeader, "10")
+	header.Set(paginationPageHeader, "1")
+	header.Set(paginationPageTotalHeader, pageTotal)
+	header.Set(paginationPageSizeHeader, "5")
+	for _, opt := range opts {
+		opt(header)
+	}
+	return &http.Response{Header: header}
+}
+
+func withoutHeader(name string) func(http.Header) {
+	return func(header http.Header) {
+		header.Del(name)
+	}
+}
+
+func TestPaginateAllHTTP_ParsesHeader(t *testing.T) {
+	calls := 0
+	exec := func(page, pageSize int64) ([]int64, *http.Response, error) {
+		calls++
+		resp := paginationResponse("2")
+		switch page {
+		case 1:
+			return makeItems(0, pageSize), resp, nil
+		case 2:
+			return makeItems(pageSize, pageSize), resp, nil
+		}
+		t.Fatalf("unexpected page %d", page)
+		return nil, nil, nil
+	}
+
+	got, err := PaginateAllHTTP[int64](exec, PaginationOptions{PageSize: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 10 {
+		t.Fatalf("expected 10 results, got %d", len(got))
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 exec calls, got %d", calls)
+	}
+}
+
+func TestPaginateAllHTTP_MissingHeaderErrors(t *testing.T) {
+	calls := 0
+	exec := func(page, pageSize int64) ([]int64, *http.Response, error) {
+		calls++
+		resp := &http.Response{Header: http.Header{}}
+		return makeItems(0, pageSize), resp, nil
+	}
+
+	_, err := PaginateAllHTTP[int64](exec, PaginationOptions{PageSize: 5})
+	if err == nil {
+		t.Fatalf("expected missing header error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing required pagination header") {
+		t.Fatalf("expected missing header error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 exec call, got %d", calls)
+	}
+}
+
+func TestPaginateAllHTTP_NilResponseErrors(t *testing.T) {
+	exec := func(page, pageSize int64) ([]int64, *http.Response, error) {
+		return nil, nil, nil
+	}
+
+	_, err := PaginateAllHTTP[int64](exec, PaginationOptions{PageSize: 5})
+	if err == nil {
+		t.Fatalf("expected nil response error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing HTTP response") {
+		t.Fatalf("expected nil response error, got %v", err)
+	}
+}
+
+func TestPaginateAllHTTP_ExecErrorPropagates(t *testing.T) {
+	sentinel := errors.New("api boom")
+	exec := func(page, pageSize int64) ([]int64, *http.Response, error) {
+		return nil, nil, sentinel
+	}
+
+	_, err := PaginateAllHTTP[int64](exec, PaginationOptions{PageSize: 5})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}

--- a/cloudsmith/pagination_test.go
+++ b/cloudsmith/pagination_test.go
@@ -300,6 +300,26 @@ func TestPaginateAllHTTP_NilResponseErrors(t *testing.T) {
 	}
 }
 
+func TestPaginateAllHTTP_NotFoundReturnsEmpty(t *testing.T) {
+	calls := 0
+	exec := func(page, pageSize int64) ([]int64, *http.Response, error) {
+		calls++
+		resp := &http.Response{StatusCode: http.StatusNotFound, Header: http.Header{}}
+		return nil, resp, nil
+	}
+
+	out, err := PaginateAllHTTP[int64](exec, PaginationOptions{PageSize: 5})
+	if err != nil {
+		t.Fatalf("expected nil error on 404, got %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty result on 404, got %d items", len(out))
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 exec call, got %d", calls)
+	}
+}
+
 func TestPaginateAllHTTP_ExecErrorPropagates(t *testing.T) {
 	sentinel := errors.New("api boom")
 	exec := func(page, pageSize int64) ([]int64, *http.Response, error) {

--- a/cloudsmith/resource_oidc.go
+++ b/cloudsmith/resource_oidc.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
@@ -287,43 +286,33 @@ func resourceOIDC() *schema.Resource {
 	}
 }
 
-// returns a list of maps for state.
 func retrieveAllDynamicMappings(pc *providerConfig, namespace, slugPerm string) ([]map[string]interface{}, error) {
-	var result []map[string]interface{}
-	const pageSize int64 = 500
-	var page int64 = 1
-	for {
-		req := pc.APIClient.OrgsApi.OrgsOpenidConnectDynamicMappingsList(pc.Auth, namespace, slugPerm).Page(page).PageSize(pageSize)
-		dmList, resp, err := pc.APIClient.OrgsApi.OrgsOpenidConnectDynamicMappingsListExecute(req)
-		if err != nil {
-			if resp != nil && is404(resp) { // treat missing as none
-				break
-			}
-			return nil, err
+	exec := func(page, ps int64) ([]cloudsmith.DynamicMapping, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsOpenidConnectDynamicMappingsList(pc.Auth, namespace, slugPerm).
+			Page(page).
+			PageSize(ps)
+		results, resp, err := pc.APIClient.OrgsApi.OrgsOpenidConnectDynamicMappingsListExecute(req)
+		if is404(resp) {
+			return nil, resp, nil
 		}
-		for _, dm := range dmList {
-			result = append(result, map[string]interface{}{
-				"claim_value":     dm.GetClaimValue(),
-				"service_account": dm.GetServiceAccount(),
-			})
-		}
-		if resp == nil {
-			break
-		}
-		pageTotalStr := resp.Header.Get("X-Pagination-Pagetotal")
-		if pageTotalStr == "" {
-			break
-		}
-		totalPages, err := strconv.ParseInt(pageTotalStr, 10, 64)
-		if err != nil || page >= totalPages {
-			break
-		}
-		page++
+		return results, resp, err
 	}
-	return result, nil
+
+	mappings, err := PaginateAllHTTP[cloudsmith.DynamicMapping](exec, PaginationOptions{PageSize: 500})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]map[string]interface{}, 0, len(mappings))
+	for _, dm := range mappings {
+		out = append(out, map[string]interface{}{
+			"claim_value":     dm.GetClaimValue(),
+			"service_account": dm.GetServiceAccount(),
+		})
+	}
+	return out, nil
 }
 
-// Helper utilities
 func buildDynamicMappingObjectsFromSet(set *schema.Set) []cloudsmith.DynamicMapping {
 	if set == nil {
 		return nil

--- a/cloudsmith/resource_repository_privileges.go
+++ b/cloudsmith/resource_repository_privileges.go
@@ -238,30 +238,13 @@ func resourceRepositoryPrivilegesRead(d *schema.ResourceData, m interface{}) err
 	organization := requiredString(d, "organization")
 	repository := requiredString(d, "repository")
 
-	var allPrivileges []cloudsmith.RepositoryPrivilegeDict
-	page := int64(1)
-	pageSize := int64(1000)
-
-	for {
-		req := pc.APIClient.ReposApi.ReposPrivilegesList(pc.Auth, organization, repository)
-		req = req.Page(page)
-		req = req.PageSize(pageSize)
-		privileges, resp, err := pc.APIClient.ReposApi.ReposPrivilegesListExecute(req)
-		if err != nil {
-			if is404(resp) {
-				d.SetId("")
-				return nil
-			}
-			return err
-		}
-
-		allPrivileges = append(allPrivileges, privileges.GetPrivileges()...)
-
-		// Check if we have retrieved all pages
-		if int64(len(privileges.GetPrivileges())) < pageSize {
-			break
-		}
-		page++
+	allPrivileges, notFound, err := retrieveRepositoryPrivilegePages(pc, organization, repository)
+	if err != nil {
+		return err
+	}
+	if notFound {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("service", flattenRepositoryPrivilegeServices(allPrivileges))
@@ -275,6 +258,39 @@ func resourceRepositoryPrivilegesRead(d *schema.ResourceData, m interface{}) err
 	d.Set("repository", repository)
 
 	return nil
+}
+
+func retrieveRepositoryPrivilegePages(pc *providerConfig, organization, repository string) ([]cloudsmith.RepositoryPrivilegeDict, bool, error) {
+	const pageSize int64 = 1000
+
+	// ReposPrivilegesList accepts page/page_size but does not emit the standard
+	// X-Pagination-* response headers used by PaginateAllHTTP.
+	var all []cloudsmith.RepositoryPrivilegeDict
+	for page := int64(1); ; page++ {
+		if page > DefaultMaxPages {
+			return nil, false, fmt.Errorf(
+				"repository privileges pagination exceeded MaxPages (%d); aborting to prevent runaway iteration",
+				DefaultMaxPages,
+			)
+		}
+
+		req := pc.APIClient.ReposApi.ReposPrivilegesList(pc.Auth, organization, repository).
+			Page(page).
+			PageSize(pageSize)
+		privileges, resp, err := pc.APIClient.ReposApi.ReposPrivilegesListExecute(req)
+		if is404(resp) {
+			return nil, true, nil
+		}
+		if err != nil {
+			return nil, false, err
+		}
+
+		pagePrivileges := privileges.GetPrivileges()
+		all = append(all, pagePrivileges...)
+		if int64(len(pagePrivileges)) < pageSize {
+			return all, false, nil
+		}
+	}
 }
 
 func resourceRepositoryPrivilegesDelete(d *schema.ResourceData, m interface{}) error {

--- a/cloudsmith/resource_repository_privileges.go
+++ b/cloudsmith/resource_repository_privileges.go
@@ -264,16 +264,10 @@ func retrieveRepositoryPrivilegePages(pc *providerConfig, organization, reposito
 	const pageSize int64 = 1000
 
 	// ReposPrivilegesList accepts page/page_size but does not emit the standard
-	// X-Pagination-* response headers used by PaginateAllHTTP.
+	// X-Pagination-* response headers used by PaginateAllHTTP. Iteration stops
+	// when a short page is returned.
 	var all []cloudsmith.RepositoryPrivilegeDict
 	for page := int64(1); ; page++ {
-		if page > DefaultMaxPages {
-			return nil, false, fmt.Errorf(
-				"repository privileges pagination exceeded MaxPages (%d); aborting to prevent runaway iteration",
-				DefaultMaxPages,
-			)
-		}
-
 		req := pc.APIClient.ReposApi.ReposPrivilegesList(pc.Auth, organization, repository).
 			Page(page).
 			PageSize(pageSize)

--- a/cloudsmith/resource_saml.go
+++ b/cloudsmith/resource_saml.go
@@ -3,7 +3,7 @@ package cloudsmith
 import (
 	"context"
 	"fmt"
-	"strconv"
+	"net/http"
 	"strings"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
@@ -68,63 +68,18 @@ func samlCreate(d *schema.ResourceData, m interface{}) error {
 	return samlRead(d, m)
 }
 
-func retrieveSAMLSyncListPage(pc *providerConfig, organization string, pageSize int64, pageCount int64) ([]cloudsmith.OrganizationGroupSync, int64, error) {
-	req := pc.APIClient.OrgsApi.OrgsSamlGroupSyncList(pc.Auth, organization)
-	req = req.Page(pageCount)
-	req = req.PageSize(pageSize)
-
-	samlPage, resp, err := pc.APIClient.OrgsApi.OrgsSamlGroupSyncListExecute(req)
-	if err != nil {
+func retrieveSAMLSyncListPages(pc *providerConfig, organization string) ([]cloudsmith.OrganizationGroupSync, error) {
+	exec := func(page, ps int64) ([]cloudsmith.OrganizationGroupSync, *http.Response, error) {
+		req := pc.APIClient.OrgsApi.OrgsSamlGroupSyncList(pc.Auth, organization).
+			Page(page).
+			PageSize(ps)
+		results, resp, err := pc.APIClient.OrgsApi.OrgsSamlGroupSyncListExecute(req)
 		if is404(resp) {
-			return nil, 0, nil
+			return nil, resp, nil
 		}
-		return nil, 0, err
+		return results, resp, err
 	}
-
-	pageTotal, err := strconv.ParseInt(resp.Header.Get("X-Pagination-Pagetotal"), 10, 64)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return samlPage, pageTotal, nil
-
-}
-
-func retrieveSAMLSyncListPages(pc *providerConfig, organization string, pageSize int64, pageCount int64) ([]cloudsmith.OrganizationGroupSync, error) {
-	var pageCurrentCount int64 = 1
-
-	// A negative or zero count is assumed to mean retrieve the largest size page
-	samlList := []cloudsmith.OrganizationGroupSync{}
-	if pageSize == -1 || pageSize == 0 {
-		pageSize = 100
-	}
-
-	// If no count is supplied assumed to mean retrieve all pages
-	// we have to retrieve a page to get this count
-	if pageCount == -1 || pageCount == 0 {
-		var samlPage []cloudsmith.OrganizationGroupSync
-		var err error
-		samlPage, _, err = retrieveSAMLSyncListPage(pc, organization, pageSize, 1)
-		if err != nil {
-			return nil, err
-		}
-		samlList = append(samlList, samlPage...)
-		pageCurrentCount++
-	}
-
-	for {
-		samlPage, totalPages, err := retrieveSAMLSyncListPage(pc, organization, pageSize, pageCurrentCount)
-		if err != nil {
-			return nil, err
-		}
-		samlList = append(samlList, samlPage...)
-		if pageCurrentCount >= totalPages {
-			break
-		}
-		pageCurrentCount++
-	}
-
-	return samlList, nil
+	return PaginateAllHTTP[cloudsmith.OrganizationGroupSync](exec, PaginationOptions{})
 }
 
 func samlRead(d *schema.ResourceData, m interface{}) error {
@@ -132,13 +87,11 @@ func samlRead(d *schema.ResourceData, m interface{}) error {
 
 	organization := requiredString(d, "organization")
 
-	var pageCount, pageSize int64 = -1, -1
-	samlList, err := retrieveSAMLSyncListPages(pc, organization, pageSize, pageCount)
+	samlList, err := retrieveSAMLSyncListPages(pc, organization)
 	if err != nil {
 		return err
 	}
 
-	// Iterate over the saml array to find the matching item
 	for _, item := range samlList {
 		if item.GetSlugPerm() == d.Id() {
 			d.Set("idp_key", item.IdpKey)
@@ -153,7 +106,6 @@ func samlRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	// If no matching item is found, unset the ID and return
 	d.SetId("")
 	return nil
 }

--- a/cloudsmith/resource_saml.go
+++ b/cloudsmith/resource_saml.go
@@ -68,7 +68,11 @@ func samlCreate(d *schema.ResourceData, m interface{}) error {
 	return samlRead(d, m)
 }
 
-func retrieveSAMLSyncListPages(pc *providerConfig, organization string) ([]cloudsmith.OrganizationGroupSync, error) {
+func samlRead(d *schema.ResourceData, m interface{}) error {
+	pc := m.(*providerConfig)
+
+	organization := requiredString(d, "organization")
+
 	exec := func(page, ps int64) ([]cloudsmith.OrganizationGroupSync, *http.Response, error) {
 		req := pc.APIClient.OrgsApi.OrgsSamlGroupSyncList(pc.Auth, organization).
 			Page(page).
@@ -79,15 +83,7 @@ func retrieveSAMLSyncListPages(pc *providerConfig, organization string) ([]cloud
 		}
 		return results, resp, err
 	}
-	return PaginateAllHTTP[cloudsmith.OrganizationGroupSync](exec, PaginationOptions{})
-}
-
-func samlRead(d *schema.ResourceData, m interface{}) error {
-	pc := m.(*providerConfig)
-
-	organization := requiredString(d, "organization")
-
-	samlList, err := retrieveSAMLSyncListPages(pc, organization)
+	samlList, err := PaginateAllHTTP[cloudsmith.OrganizationGroupSync](exec, PaginationOptions{})
 	if err != nil {
 		return err
 	}

--- a/docs/data-sources/repository_connected_list.md
+++ b/docs/data-sources/repository_connected_list.md
@@ -2,7 +2,7 @@
 
 The `cloudsmith_repository_connected_list` data source returns all connected repositories configured for a given source repository.
 
-By default, each source repository has a soft limit of 5 connected repository connections. Contact Cloudsmith support if you need this limit increased.
+By default, each source repository has a soft limit of 5 connected repositories. Contact Cloudsmith support if you need this limit increased.
 
 ## Example Usage
 

--- a/docs/data-sources/repository_connected_list.md
+++ b/docs/data-sources/repository_connected_list.md
@@ -2,6 +2,8 @@
 
 The `cloudsmith_repository_connected_list` data source returns all connected repositories configured for a given source repository.
 
+By default, each source repository has a soft limit of 5 connected repository connections. Contact Cloudsmith support if you need this limit increased.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/repository_connected.md
+++ b/docs/resources/repository_connected.md
@@ -2,6 +2,8 @@
 
 The repository connected resource allows the management of connections between two Cloudsmith repositories within the same organization. A connection links a source repository to a target repository so that requests to the source can be resolved against the target as well, according to a configurable lookup priority.
 
+By default, each source repository has a soft limit of 5 connected repository connections. Contact Cloudsmith support if you need this limit increased.
+
 See [docs.cloudsmith.com](https://docs.cloudsmith.com) for full Connected Repositories documentation.
 
 ## Example Usage

--- a/docs/resources/repository_connected.md
+++ b/docs/resources/repository_connected.md
@@ -2,7 +2,7 @@
 
 The repository connected resource allows the management of connections between two Cloudsmith repositories within the same organization. A connection links a source repository to a target repository so that requests to the source can be resolved against the target as well, according to a configurable lookup priority.
 
-By default, each source repository has a soft limit of 5 connected repository connections. Contact Cloudsmith support if you need this limit increased.
+By default, each source repository has a soft limit of 5 connected repositories. Contact Cloudsmith support if you need this limit increased.
 
 See [docs.cloudsmith.com](https://docs.cloudsmith.com) for full Connected Repositories documentation.
 


### PR DESCRIPTION
# Description

This PR introduces a shared pagination helper for Cloudsmith list endpoints and migrates the existing duplicated pagination loops to use it. The goal is to make list-style data sources and resource reads fetch paginated results consistently, while keeping the individual API call setup close to each resource.

The PR also documents the connected repositories soft limit in the resource and data source docs.

Default Page Size set to: 100

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Tests
- [ ] Other (please describe)

## Testing

- Added unit coverage for the shared pagination helper, including multi-page reads, required pagination headers, malformed headers, max page protection, max result limits, and HTTP-response based pagination.
- Ran:
  - `go test ./cloudsmith -run 'TestPaginateAll|TestParsePageTotal' -count=1 -timeout=30s`
  - `go test ./cloudsmith -run '^$' -count=1 -timeout=30s`

## Additional Notes

- No Terraform schema changes are introduced.
- List operations now use one shared implementation for page size defaults, required Cloudsmith pagination header parsing, and runaway pagination protection.
- `most_recent` package lookups still request a single result.
- Repository privileges reads now use an endpoint-specific paged loop because that endpoint accepts `page`/`page_size` but does not emit the standard pagination headers.
- Connected repository documentation now notes the default soft limit of 5 connections per source repository and directs users to Cloudsmith support if they need the limit increased.
