### PR TITLE
fix(eng-12346): Fix for Issue #203

### DIFF
--- a/cloudsmith/resource_repository_privileges.go
+++ b/cloudsmith/resource_repository_privileges.go
@@ -214,7 +214,7 @@ func resourceRepositoryPrivilegesCreateUpdate(d *schema.ResourceData, m interfac
 
 	_, err = pc.APIClient.ReposApi.ReposPrivilegesUpdateExecute(req)
 	if err != nil {
-		return err
+		return formatAPIError(err)
 	}
 
 	d.SetId(fmt.Sprintf("%s.%s", organization, repository))
@@ -252,7 +252,7 @@ func resourceRepositoryPrivilegesRead(d *schema.ResourceData, m interface{}) err
 				d.SetId("")
 				return nil
 			}
-			return err
+			return formatAPIError(err)
 		}
 
 		allPrivileges = append(allPrivileges, privileges.GetPrivileges()...)
@@ -290,7 +290,7 @@ func resourceRepositoryPrivilegesDelete(d *schema.ResourceData, m interface{}) e
 
 	_, err := pc.APIClient.ReposApi.ReposPrivilegesUpdateExecute(req)
 	if err != nil {
-		return err
+		return formatAPIError(err)
 	}
 
 	checkerFunc := func() error {

--- a/cloudsmith/resource_repository_retention_rule.go
+++ b/cloudsmith/resource_repository_retention_rule.go
@@ -53,18 +53,9 @@ func resourceRepoRetentionRuleUpdate(d *schema.ResourceData, meta interface{}) e
 	req = req.Data(updateData)
 
 	// Execute the request
-	_, httpResp, err := req.Execute()
+	_, _, err := req.Execute()
 	if err != nil {
-		switch httpResp.StatusCode {
-		case 400:
-			return fmt.Errorf("request could not be processed: %s", err)
-		case 404:
-			return fmt.Errorf("namespace or repository not found: %s", err)
-		case 422:
-			return fmt.Errorf("missing or invalid parameters: %s", err)
-		default:
-			return fmt.Errorf("error updating repository retention rule: %s", err)
-		}
+		return fmt.Errorf("error updating repository retention rule: %w", formatAPIError(err))
 	}
 
 	d.SetId(fmt.Sprintf("%s.%s", namespace, repo))
@@ -110,18 +101,9 @@ func resourceRepoRetentionRuleRead(d *schema.ResourceData, meta interface{}) err
 	repo := requiredString(d, "repository")
 
 	// Execute the request
-	resp, httpResp, err := pc.APIClient.ReposApi.RepoRetentionRead(pc.Auth, namespace, repo).Execute()
+	resp, _, err := pc.APIClient.ReposApi.RepoRetentionRead(pc.Auth, namespace, repo).Execute()
 	if err != nil {
-		switch httpResp.StatusCode {
-		case 400:
-			return fmt.Errorf("request could not be processed: %s", err)
-		case 404:
-			return fmt.Errorf("namespace or repository not found: %s", err)
-		case 422:
-			return fmt.Errorf("missing or invalid parameters: %s", err)
-		default:
-			return fmt.Errorf("error reading repository retention rule: %s", err)
-		}
+		return fmt.Errorf("error reading repository retention rule: %w", formatAPIError(err))
 	}
 
 	d.Set("retention_count_limit", resp.RetentionCountLimit)
@@ -155,16 +137,10 @@ func resourceRepoRetentionRuleDelete(d *schema.ResourceData, meta interface{}) e
 
 	_, httpResp, err := req.Execute()
 	if err != nil {
-		switch httpResp.StatusCode {
-		case 400:
-			return fmt.Errorf("request could not be processed: %s", err)
-		case 404:
+		if httpResp != nil && httpResp.StatusCode == 404 {
 			return nil
-		case 422:
-			return fmt.Errorf("missing or invalid parameters: %s", err)
-		default:
-			return fmt.Errorf("error disabling repository retention rule: %s", err)
 		}
+		return fmt.Errorf("error disabling repository retention rule: %w", formatAPIError(err))
 	}
 
 	d.SetId("")

--- a/cloudsmith/resource_saml_auth.go
+++ b/cloudsmith/resource_saml_auth.go
@@ -69,9 +69,9 @@ func samlAuthCreate(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	}
 
 	req := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdate(pc.Auth, organization).Data(*samlAuth)
-	result, resp, err := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdateExecute(req)
+	result, _, err := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdateExecute(req)
 	if err != nil {
-		return diag.FromErr(handleSAMLAuthError(err, resp, "creating SAML authentication"))
+		return diag.FromErr(handleSAMLAuthError(err, "creating SAML authentication"))
 	}
 
 	d.SetId(generateSAMLAuthID(organization, result))
@@ -101,7 +101,7 @@ func samlAuthRead(ctx context.Context, d *schema.ResourceData, m interface{}) di
 			d.SetId("")
 			return nil
 		}
-		return diag.FromErr(handleSAMLAuthError(err, resp, "reading SAML authentication"))
+		return diag.FromErr(handleSAMLAuthError(err, "reading SAML authentication"))
 	}
 
 	d.Set("organization", organization)
@@ -125,9 +125,9 @@ func samlAuthUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	}
 
 	req := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdate(pc.Auth, organization).Data(*samlAuth)
-	_, resp, err := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdateExecute(req)
+	_, _, err = pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdateExecute(req)
 	if err != nil {
-		return diag.FromErr(handleSAMLAuthError(err, resp, "updating SAML authentication"))
+		return diag.FromErr(handleSAMLAuthError(err, "updating SAML authentication"))
 	}
 	// Wait for the backend to reflect enabled/metadata state
 	if err := waitForSAMLAuthState(
@@ -156,9 +156,9 @@ func samlAuthDelete(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	samlAuth.SetSamlMetadataUrl("")
 
 	req := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdate(pc.Auth, organization).Data(*samlAuth)
-	_, resp, err := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdateExecute(req)
+	_, _, err := pc.APIClient.OrgsApi.OrgsSamlAuthenticationPartialUpdateExecute(req)
 	if err != nil {
-		return diag.FromErr(handleSAMLAuthError(err, resp, "deleting SAML authentication"))
+		return diag.FromErr(handleSAMLAuthError(err, "deleting SAML authentication"))
 	}
 
 	// Wait for the backend to reflect the disabled state
@@ -179,7 +179,7 @@ func samlAuthImport(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("SAML authentication not found for organization %s", organization)
 		}
-		return nil, handleSAMLAuthError(err, resp, "importing SAML authentication")
+		return nil, handleSAMLAuthError(err, "importing SAML authentication")
 	}
 
 	d.Set("organization", organization)
@@ -285,12 +285,11 @@ func generateSAMLAuthID(organization string, samlAuth *cloudsmith.OrganizationSA
 	return hex.EncodeToString(hash[:])
 }
 
-// handleSAMLAuthError creates formatted error messages for API operations
-func handleSAMLAuthError(err error, resp *http.Response, action string) error {
-	if resp != nil {
-		return fmt.Errorf("error %s: %v (status: %d)", action, err, resp.StatusCode)
-	}
-	return fmt.Errorf("error %s: %v", action, err)
+// handleSAMLAuthError wraps an API error with the SAML action context while
+// routing through formatAPIError so any typed ErrorDetail (detail/fields)
+// from the API is surfaced to the caller.
+func handleSAMLAuthError(err error, action string) error {
+	return fmt.Errorf("error %s: %w", action, formatAPIError(err))
 }
 
 // resourceSAMLAuth returns a schema.Resource for managing SAML authentication configuration.

--- a/cloudsmith/resource_team.go
+++ b/cloudsmith/resource_team.go
@@ -2,9 +2,7 @@ package cloudsmith
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -39,30 +37,9 @@ func resourceTeamCreate(d *schema.ResourceData, m interface{}) error {
 		Visibility:  optionalString(d, "visibility"),
 	})
 
-	team, resp, err := pc.APIClient.OrgsApi.OrgsTeamsCreateExecute(req)
+	team, _, err := pc.APIClient.OrgsApi.OrgsTeamsCreateExecute(req)
 	if err != nil {
-		if resp != nil && resp.StatusCode == 422 {
-			bodyBytes, readErr := io.ReadAll(resp.Body)
-			if readErr != nil {
-				return fmt.Errorf("encountered an error: %w", err)
-			}
-			var apiError map[string]interface{}
-			jsonErr := json.Unmarshal(bodyBytes, &apiError)
-			if jsonErr != nil {
-				return fmt.Errorf("encountered an error: %w", err)
-			}
-			if fields, ok := apiError["fields"].(map[string]interface{}); ok {
-				for _, v := range fields {
-					if messages, ok := v.([]interface{}); ok && len(messages) > 0 {
-						if message, ok := messages[0].(string); ok {
-							return fmt.Errorf("error: %s", message)
-						}
-					}
-				}
-			}
-			return fmt.Errorf("encountered an error: %v", apiError)
-		}
-		return err
+		return formatAPIError(err)
 	}
 
 	d.SetId(team.GetSlugPerm())

--- a/cloudsmith/utils.go
+++ b/cloudsmith/utils.go
@@ -71,8 +71,25 @@ func is404(resp *http.Response) bool {
 	return resp.StatusCode == http.StatusNotFound
 }
 
-// formatAPIError extracts the response body from a generated-SDK error and
-// returns an error whose message surfaces the API-provided detail / fields.
+// apiErrorBody is a permissive parse of the JSON error body returned by the
+// Cloudsmith API. We use json.RawMessage for Fields because the SDK's typed
+// ErrorDetail uses map[string][]string, which fails to decode some real API
+// responses (e.g. nested objects). Falling back to a raw message lets us
+// surface the body verbatim instead of leaking the SDK unmarshal error.
+type apiErrorBody struct {
+	Detail string          `json:"detail"`
+	Fields json.RawMessage `json:"fields,omitempty"`
+}
+
+// formatAPIError surfaces API-provided detail/fields from a generated-SDK
+// error. Order of preference:
+//  1. SDK's typed ErrorDetail model (populated for status codes the SDK
+//     decodes per-endpoint, e.g. 400/404/422 with a compatible body).
+//  2. Raw response body parsed permissively. Required because the SDK's
+//     ErrorDetail.Fields is map[string][]string and some real API responses
+//     do not match that schema, causing the SDK to return the unmarshal
+//     error verbatim (the original bug from issue #203).
+//  3. Original error, unchanged.
 func formatAPIError(err error) error {
 	if err == nil {
 		return nil
@@ -83,15 +100,25 @@ func formatAPIError(err error) error {
 		return err
 	}
 
+	if detail, ok := apiErr.Model().(cloudsmith.ErrorDetail); ok {
+		if detail.HasFields() {
+			return fmt.Errorf("%s (fields: %v)", detail.GetDetail(), detail.GetFields())
+		}
+		return fmt.Errorf("%s", detail.GetDetail())
+	}
+
 	body := apiErr.Body()
 	if len(body) == 0 {
 		return err
 	}
+	return formatAPIErrorBody(body)
+}
 
-	var parsed struct {
-		Detail string          `json:"detail"`
-		Fields json.RawMessage `json:"fields,omitempty"`
-	}
+// formatAPIErrorBody parses a raw API error body and returns a formatted error.
+// Split out from formatAPIError so the parsing logic is unit-testable without
+// needing to construct a generated-SDK error (its body field is unexported).
+func formatAPIErrorBody(body []byte) error {
+	var parsed apiErrorBody
 	if jsonErr := json.Unmarshal(body, &parsed); jsonErr == nil && parsed.Detail != "" {
 		if len(parsed.Fields) > 0 && string(parsed.Fields) != "null" {
 			return fmt.Errorf("%s (fields: %s)", parsed.Detail, string(parsed.Fields))

--- a/cloudsmith/utils.go
+++ b/cloudsmith/utils.go
@@ -1,6 +1,7 @@
 package cloudsmith
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -68,6 +69,37 @@ func is404(resp *http.Response) bool {
 	}
 
 	return resp.StatusCode == http.StatusNotFound
+}
+
+// formatAPIError extracts the response body from a generated-SDK error and
+// returns an error whose message surfaces the API-provided detail / fields.
+func formatAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var apiErr *cloudsmith.GenericOpenAPIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+
+	body := apiErr.Body()
+	if len(body) == 0 {
+		return err
+	}
+
+	var parsed struct {
+		Detail string          `json:"detail"`
+		Fields json.RawMessage `json:"fields,omitempty"`
+	}
+	if jsonErr := json.Unmarshal(body, &parsed); jsonErr == nil && parsed.Detail != "" {
+		if len(parsed.Fields) > 0 && string(parsed.Fields) != "null" {
+			return fmt.Errorf("%s (fields: %s)", parsed.Detail, string(parsed.Fields))
+		}
+		return fmt.Errorf("%s", parsed.Detail)
+	}
+
+	return fmt.Errorf("API error: %s", string(body))
 }
 
 func nullableInt64(d *schema.ResourceData, name string) cloudsmith.NullableInt64 {

--- a/cloudsmith/utils_test.go
+++ b/cloudsmith/utils_test.go
@@ -1,0 +1,84 @@
+//nolint:testpackage
+package cloudsmith
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFormatAPIError_Nil(t *testing.T) {
+	if got := formatAPIError(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestFormatAPIError_NonAPIError(t *testing.T) {
+	orig := errors.New("boom")
+	got := formatAPIError(orig)
+	if got != orig {
+		t.Fatalf("expected original error to pass through, got %v", got)
+	}
+}
+
+// TestFormatAPIErrorBody covers the raw-body fallback path used by
+// formatAPIError when the SDK's typed ErrorDetail model is not populated.
+// This path is the one that fixes issue #203: the SDK declares
+// ErrorDetail.Fields as map[string][]string and fails to decode real
+// responses whose fields contain non-[]string values, leaving callers with
+// an opaque "json: cannot unmarshal ..." message. The raw-body parse here
+// tolerates any fields shape via json.RawMessage.
+//
+// The primary SDK-native path (apiErr.Model().(cloudsmith.ErrorDetail)) is
+// not unit-testable: GenericOpenAPIError's body/model fields are unexported,
+// so a populated instance cannot be constructed from outside the SDK. That
+// path is exercised by acceptance tests against the live API.
+func TestFormatAPIErrorBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "detail only",
+			body: `{"detail":"Authentication credentials were not provided."}`,
+			want: "Authentication credentials were not provided.",
+		},
+		{
+			name: "detail with non-[]string fields (issue #203 shape)",
+			body: `{"detail":"Invalid input.","fields":{"slug":["Enter a valid slug."]}}`,
+			want: `Invalid input. (fields: {"slug":["Enter a valid slug."]})`,
+		},
+		{
+			name: "detail with nested-object fields (SDK decode would fail)",
+			body: `{"detail":"Validation failed.","fields":{"privileges":{"0":{"slug":["Invalid."]}}}}`,
+			want: `Validation failed. (fields: {"privileges":{"0":{"slug":["Invalid."]}}})`,
+		},
+		{
+			name: "detail with null fields",
+			body: `{"detail":"Forbidden.","fields":null}`,
+			want: "Forbidden.",
+		},
+		{
+			name: "unparseable body falls back to raw",
+			body: `not-json`,
+			want: "API error: not-json",
+		},
+		{
+			name: "json without detail falls back to raw",
+			body: `{"other":"value"}`,
+			want: `API error: {"other":"value"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := formatAPIErrorBody([]byte(tc.body))
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if err.Error() != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Fix [#203](https://github.com/cloudsmith-io/terraform-provider-cloudsmith/issues/203): JSON unmarshal error masks API validation message in `cloudsmith_repository_privileges`.

The generated SDK model `cloudsmith.ErrorDetail` types `Fields` as `*map[string][]string`, but the Cloudsmith API returns `fields` as a nested object for this endpoint (e.g. `{"privileges": {"detail": "Invalid service(s) specified [...]"}}`). The SDK fails to unmarshal and replaces the status-line error with the raw `json:` decode error, while keeping the response body on the unexported `body` field of `GenericOpenAPIError`. The provider returned that opaque message straight to Terraform.

The fix is a single helper, `formatAPIError`, that:

1. Prefers the SDK-native typed model via `apiErr.Model().(cloudsmith.ErrorDetail)` when the SDK successfully decoded the response (status codes the SDK handles per-endpoint, typically 400/404/422 with a schema-compatible body).
2. Falls back to a permissive parse of the raw response body (`Detail string`, `Fields json.RawMessage`) when the SDK's typed decode failed — which is the exact path that issue #203 hits.
3. Returns the original error unchanged for anything that isn't an SDK API error.

The helper is then used by the resource hit in the bug report, and by the three other resources doing the worst hand-rolled error parsing.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [x] Tests
- [ ] Other (please describe)

## Testing

- `go build ./...` and `go vet ./...`: clean.
- `go test ./cloudsmith/ -run '^TestFormatAPIError'`: passes (covers the fallback path, including the issue #203 shape).

### Before (`cloudsmith_repository_privileges` with a nonexistent `service.slug`)

```text
cloudsmith_repository_privileges.issue_203: Creating...
╷
│ Error: json: cannot unmarshal object into Go struct field _ErrorDetail.fields of type []string
│
│   with cloudsmith_repository_privileges.issue_203,
│   on main.tf line 49, in resource "cloudsmith_repository_privileges" "issue_203":
│   49: resource "cloudsmith_repository_privileges" "issue_203" {
│
╵
```

### After (same input)

```text
cloudsmith_repository_privileges.issue_203: Creating...
╷
│ Error: Invalid input. (fields: {"privileges":{"detail":"Invalid service(s) specified ['this-service-slug-does-not-exist-xyz']"}})
│
│   with cloudsmith_repository_privileges.issue_203,
│   on main.tf line 49, in resource "cloudsmith_repository_privileges" "issue_203":
│   49: resource "cloudsmith_repository_privileges" "issue_203" {
│
╵
```
