### PR TITLE
fix(sup-96): issue with storage region API call

### DIFF
--- a/cloudsmith/resource_repository.go
+++ b/cloudsmith/resource_repository.go
@@ -27,7 +27,7 @@ func importRepository(ctx context.Context, d *schema.ResourceData, m interface{}
 func resourceRepositoryStorageRegionUpdate(d *schema.ResourceData, m interface{}) error {
 	pc := m.(*providerConfig)
 
-	req := pc.APIClient.ReposApi.ReposTransferRegion(pc.Auth, d.Get("namespace").(string), d.Get("name").(string))
+	req := pc.APIClient.ReposApi.ReposTransferRegion(pc.Auth, d.Get("namespace").(string), d.Id())
 	req = req.Data(cloudsmith.RepositoryTransferRegionRequest{
 		StorageRegion: optionalString(d, "storage_region"),
 	})

--- a/cloudsmith/resource_repository_storage_region_test.go
+++ b/cloudsmith/resource_repository_storage_region_test.go
@@ -1,0 +1,70 @@
+//nolint:testpackage
+package cloudsmith
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cloudsmithapi "github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceRepositoryStorageRegionUpdate_UsesResourceID(t *testing.T) {
+	t.Parallel()
+
+	var (
+		requestPath string
+		requestBody string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		requestBody = string(body)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := cloudsmithapi.NewConfiguration()
+	config.Servers = cloudsmithapi.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	pc := &providerConfig{
+		APIClient: cloudsmithapi.NewAPIClient(config),
+		Auth: context.WithValue(
+			context.Background(),
+			cloudsmithapi.ContextAPIKeys,
+			map[string]cloudsmithapi.APIKey{
+				"apikey": {Key: "test-api-key"},
+			},
+		),
+	}
+
+	rd := schema.TestResourceDataRaw(t, resourceRepository().Schema, map[string]interface{}{
+		"namespace":      "example-org",
+		"name":           "display-name-should-not-be-used",
+		"storage_region": "us-ohio",
+	})
+	rd.SetId("repo-id-fixture")
+
+	if err := resourceRepositoryStorageRegionUpdate(rd, pc); err != nil {
+		t.Fatalf("resourceRepositoryStorageRegionUpdate() error = %v", err)
+	}
+
+	expectedPath := "/repos/example-org/repo-id-fixture/transfer-region/"
+	if requestPath != expectedPath {
+		t.Fatalf("unexpected request path %q, expected %q", requestPath, expectedPath)
+	}
+	if !strings.Contains(requestBody, `"storage_region":"us-ohio"`) {
+		t.Fatalf("unexpected request body %q", requestBody)
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes repository storage region updates for cloudsmith_repository by using the Terraform resource identifier in the transfer-region API call instead of the repository display name.

Previously, changing storage_region could fail with:
- Error: error updating repository: 404 Not Found (Not found.)

## Root Cause
The storage-region update path called the transfer-region endpoint with repository name.  
For this endpoint, the repository path parameter must be the canonical repository identifier (the value stored as Terraform state id), not the display name.

## Changes
- Updated storage region transfer call to use Terraform state id (d.Id()).
- Added a regression unit test to verify:
1. request path uses resource id
2. request payload contains storage_region

## Files Changed
- resource_repository.go
- resource_repository_storage_region_test.go

## Validation
- Ran:
  - go test ./cloudsmith -run TestResourceRepositoryStorageRegionUpdate_UsesResourceID -count=1
- Result: pass

## Impact
- Fixes 404 failures on in-place storage_region updates.
- Aligns identifier usage with existing repository read/update/delete behavior.
- No schema changes and no breaking API surface changes.