### PR TITLE
fix(ENG-12974): Fail fast when upstream activation is disabled

### DIFF
--- a/cloudsmith/resource_repository_upstream.go
+++ b/cloudsmith/resource_repository_upstream.go
@@ -2,6 +2,7 @@ package cloudsmith
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -105,6 +106,8 @@ type Upstream interface {
 	GetExtraHeader2() string
 	GetExtraValue1() string
 	GetExtraValue2() string
+	GetDisableReason() string
+	GetDisableReasonText() string
 	GetCreatedAt() time.Time
 	GetIsActive() bool
 	GetMode() string
@@ -129,6 +132,47 @@ func importUpstream(_ context.Context, d *schema.ResourceData, _ interface{}) ([
 	_ = d.Set(UpstreamType, idParts[2])
 	d.SetId(idParts[3])
 	return []*schema.ResourceData{d}, nil
+}
+
+type upstreamActivationDisabledError struct {
+	slug   string
+	reason string
+}
+
+func (e upstreamActivationDisabledError) Error() string {
+	return fmt.Sprintf(
+		"upstream (%s) was disabled during activation: %s. Check the upstream status in the Cloudsmith UI.",
+		e.slug,
+		e.reason,
+	)
+}
+
+func actionableUpstreamDisableReason(disableReasonText, disableReason string) string {
+	if reason := normalizeUpstreamDisableReason(disableReasonText); reason != "" {
+		return reason
+	}
+	return normalizeUpstreamDisableReason(disableReason)
+}
+
+func normalizeUpstreamDisableReason(reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" || strings.EqualFold(reason, "N/A") {
+		return ""
+	}
+	return reason
+}
+
+func checkUpstreamActivation(upstream Upstream, slug string) error {
+	if upstream.GetIsActive() {
+		return nil
+	}
+	if reason := actionableUpstreamDisableReason(upstream.GetDisableReasonText(), upstream.GetDisableReason()); reason != "" {
+		return upstreamActivationDisabledError{
+			slug:   slug,
+			reason: reason,
+		}
+	}
+	return errKeepWaiting
 }
 
 // readCertificateContent reads and validates certificate content
@@ -612,12 +656,13 @@ func resourceRepositoryUpstreamCreate(d *schema.ResourceData, m interface{}) err
 				}
 				return err
 			}
-			if !upstream.GetIsActive() {
-				return errKeepWaiting
-			}
-			return nil
+			return checkUpstreamActivation(upstream, d.Id())
 		}
 		if err := waiter(activeChecker, 5*time.Minute, 10*time.Second); err != nil {
+			var disabledErr upstreamActivationDisabledError
+			if errors.As(err, &disabledErr) {
+				return disabledErr
+			}
 			return fmt.Errorf("error waiting for upstream (%s) to become active: %w", d.Id(), err)
 		}
 	}

--- a/cloudsmith/resource_repository_upstream_test.go
+++ b/cloudsmith/resource_repository_upstream_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -17,6 +18,117 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+type testUpstream struct {
+	isActive          bool
+	disableReason     string
+	disableReasonText string
+}
+
+func (u testUpstream) GetAuthMode() string          { return "" }
+func (u testUpstream) GetAuthSecret() string        { return "" }
+func (u testUpstream) GetAuthUsername() string      { return "" }
+func (u testUpstream) GetExtraHeader1() string      { return "" }
+func (u testUpstream) GetExtraHeader2() string      { return "" }
+func (u testUpstream) GetExtraValue1() string       { return "" }
+func (u testUpstream) GetExtraValue2() string       { return "" }
+func (u testUpstream) GetDisableReason() string     { return u.disableReason }
+func (u testUpstream) GetDisableReasonText() string { return u.disableReasonText }
+func (u testUpstream) GetCreatedAt() time.Time      { return time.Time{} }
+func (u testUpstream) GetIsActive() bool            { return u.isActive }
+func (u testUpstream) GetMode() string              { return "" }
+func (u testUpstream) GetName() string              { return "" }
+func (u testUpstream) GetPriority() int64           { return 0 }
+func (u testUpstream) GetSlugPerm() string          { return "" }
+func (u testUpstream) GetUpdatedAt() time.Time      { return time.Time{} }
+func (u testUpstream) GetUpstreamUrl() string       { return "" }
+func (u testUpstream) GetVerifySsl() bool           { return false }
+
+func TestActionableUpstreamDisableReason(t *testing.T) {
+	tests := []struct {
+		name              string
+		disableReasonText string
+		disableReason     string
+		want              string
+	}{
+		{
+			name: "empty text and reason",
+		},
+		{
+			name:              "n/a text and reason",
+			disableReasonText: "N/A",
+			disableReason:     "N/A",
+		},
+		{
+			name:              "prefers text over reason",
+			disableReasonText: "Manually disabled",
+			disableReason:     "manual",
+			want:              "Manually disabled",
+		},
+		{
+			name:          "uses reason when text is empty",
+			disableReason: "invalid_url",
+			want:          "invalid_url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := actionableUpstreamDisableReason(tt.disableReasonText, tt.disableReason)
+			if got != tt.want {
+				t.Fatalf("actionableUpstreamDisableReason(%q, %q) = %q, want %q", tt.disableReasonText, tt.disableReason, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckUpstreamActivation(t *testing.T) {
+	tests := []struct {
+		name           string
+		upstream       Upstream
+		wantErr        error
+		wantErrMessage string
+	}{
+		{
+			name:     "active",
+			upstream: testUpstream{isActive: true},
+		},
+		{
+			name:     "inactive without disable reason keeps waiting",
+			upstream: testUpstream{},
+			wantErr:  errKeepWaiting,
+		},
+		{
+			name:           "inactive with disable reason fails fast",
+			upstream:       testUpstream{disableReasonText: "Manually disabled", disableReason: "manual"},
+			wantErr:        upstreamActivationDisabledError{},
+			wantErrMessage: "upstream (test-upstream) was disabled during activation: Manually disabled. Check the upstream status in the Cloudsmith UI.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkUpstreamActivation(tt.upstream, "test-upstream")
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("checkUpstreamActivation() error = %v, want nil", err)
+				}
+				return
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				var disabledErr upstreamActivationDisabledError
+				if !errors.As(err, &disabledErr) {
+					t.Fatalf("checkUpstreamActivation() error = %v, want %T", err, tt.wantErr)
+				}
+			}
+
+			if tt.wantErrMessage != "" && err.Error() != tt.wantErrMessage {
+				t.Fatalf("checkUpstreamActivation() error = %q, want %q", err.Error(), tt.wantErrMessage)
+			}
+		})
+	}
+}
 
 func TestAccRepositoryUpstreamAlpine_basic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# Description

Fail fast when a repository upstream is disabled during async activation, surfacing Cloudsmith's `disable_reason_text` when available and falling back to `disable_reason`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Tests
- [ ] Other (please describe)

## Testing

- `go test ./cloudsmith -run 'Test(ActionableUpstreamDisableReason|CheckUpstreamActivation)' -count=1`
- `go test ./cloudsmith -run 'Test(ActionableUpstreamDisableReason|CheckUpstreamActivation|SetEntitlementPrivateBroadcasts|PolicyListDataSource|ResourceRepositoryStorageRegionUpdate)' -count=1`




