### PR TITLE
chore(deps): bump cloudsmith-api-go to v0.0.59

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsmith-io/terraform-provider-cloudsmith
 go 1.26
 
 require (
-	github.com/cloudsmith-io/cloudsmith-api-go v0.0.58
+	github.com/cloudsmith-io/cloudsmith-api-go v0.0.59
 	github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.58 h1:yJedPmSt2je3CtwxEQhb6ho9HdDcFq7Xue2JD2ImY7E=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.58/go.mod h1:xHTDgU8TyMXiWUZdn2OQR7AaZdz9M5SrNenyQU44zGQ=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.59 h1:KdAwf2TDawdg4zOGucDJ91ebGZwkLV1gBH0plq/g4a4=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.59/go.mod h1:xHTDgU8TyMXiWUZdn2OQR7AaZdz9M5SrNenyQU44zGQ=
 github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523 h1:zpwbcGnLwreE18qP6lYD5z9s36BZF/4va1Rc3tApgyQ=
 github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523/go.mod h1:yjFP2n2rHMRsL44JdJUqh+iEWqHKrbttEmDyIGllVDY=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=


### PR DESCRIPTION
Bumps the generated Go bindings from `v0.0.58` to `v0.0.59`, picking up the regenerated bindings merged in [cloudsmith-io/cloudsmith-api-go#59](https://github.com/cloudsmith-io/cloudsmith-api-go/pull/59) (CloudSmith API `1.1288.1`).

## Changes
- `go.mod` / `go.sum`: `cloudsmith-api-go v0.0.58 → v0.0.59`

## Notes
The upstream API changes are purely additive — new optional query params (`sort` on org-list, `include_connected_repositories` on the package list/groups/dependencies endpoints) and new response fields on the connected-repository, SAML, and repository models. Nothing the provider currently calls changed signature, so no provider code changes are required.

## Verification
- `go mod tidy` — clean
- `go build ./...` — passes
- `go vet ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)