### PR TITLE
fix(ENG-13727): stop blocking updates on read-only cooldown policies

### DIFF
--- a/cloudsmith/resource_policy.go
+++ b/cloudsmith/resource_policy.go
@@ -73,14 +73,6 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	workspace := requiredString(d, "workspace")
-	if requiredBool(d, "read_only") {
-		return diag.Errorf(
-			"policy %q is read-only and cannot be updated through this provider. "+
-				"To stop managing it with Terraform, use `terraform state rm`. "+
-				"To accept server-side drift, add a `lifecycle { ignore_changes = [...] }` block.",
-			d.Id(),
-		)
-	}
 	body := components.PolicyRequest{
 		Name:        requiredString(d, "name"),
 		Rego:        requiredString(d, "rego"),
@@ -215,7 +207,7 @@ func resourcePolicy() *schema.Resource {
 			},
 			"read_only": {
 				Type:        schema.TypeBool,
-				Description: "Whether the policy is read-only. Read-only policies cannot be updated through this provider.",
+				Description: "Whether the policy is read-only. Read-only policies still accept updates to their editable fields; the API rejects (422) any change to the policy's template shape.",
 				Computed:    true,
 			},
 			"created_at": {

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -45,7 +45,7 @@ default allow := true
 
 * `slug_perm` - The unique permanent slug of the policy.
 * `version` - The version of the Rego code.
-* `read_only` - Whether the policy is read-only. Read-only policies cannot be updated through this provider; use `terraform state rm` or `lifecycle { ignore_changes = [...] }`.
+* `read_only` - Whether the policy is read-only. Read-only policies still accept updates to their editable fields; the API rejects (422) any change to the policy's template shape.
 * `created_at`, `updated_at` - RFC 3339 timestamps.
 
 ## Import


### PR DESCRIPTION
# Description

`resourcePolicyUpdate` blocked *any* update client-side whenever the API's `read_only` flag was true. `read_only` doesn't mean fully locked — the SDK's own doc comment says "only specific variables can be updated" — and the API already accepts edits to a cooldown policy's editable settings (formats, window, repos), only rejecting (422) changes that alter the template shape. The provider's blanket guard prevented all of it, forcing customers to `terraform state rm` or `lifecycle { ignore_changes }` just to change a supported format.

Fix: removed the client-side guard entirely and let the update reach the API. The API's own validation now governs what's editable; its error message is surfaced as-is on rejection.

Before (`cloudsmith/resource_policy.go`):
```go
func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
	workspace := requiredString(d, "workspace")
	if requiredBool(d, "read_only") {
		return diag.Errorf(
			"policy %q is read-only and cannot be updated through this provider. "+
				"To stop managing it with Terraform, use `terraform state rm`. "+
				"To accept server-side drift, add a `lifecycle { ignore_changes = [...] }` block.",
			d.Id(),
		)
	}
	body := components.PolicyRequest{
```

After:
```go
func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
	workspace := requiredString(d, "workspace")
	body := components.PolicyRequest{
```

Also updated the `read_only` schema/doc description to stop claiming updates are blocked.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Tests
- [ ] Other (please describe)

## Testing

Manually reproduced and verified end-to-end against `bart-demo-org-terraform` using a locally-built provider binary via `dev_overrides`:
- Created a cooldown policy + `HIDDEN` `set_package_state` action (same shape as `examples/policy-workspace-example`); confirmed `read_only = true` on read, matching the customer's setup.
- Pre-fix: `terraform apply` after adding a format to `supported_formats` failed with the exact reported error.
- Post-fix: same apply succeeds and persists the change.
- Confirmed the guard rail still works: an edit that changes the policy's template shape now surfaces the API's actual 422 (`"Only configurable variables can be modified on an index-applicable policy. The policy structure has changed."`) instead of either the old blanket client-side block or a silent bad update.
- Test policy/action cleaned up (`terraform destroy`) afterward.

## Additional Notes

Linear: ENG-13727