### PR TITLE
feat: add Terraform support for organization usage limits

### DIFF
--- a/cloudsmith/data_source_package.go
+++ b/cloudsmith/data_source_package.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"time"
 
-	cloudsmith_api "github.com/cloudsmith-io/cloudsmith-api-go"
+	cloudsmithapi "github.com/cloudsmith-io/cloudsmith-api-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -28,7 +28,7 @@ type Checksums struct {
 	SHA512 string
 }
 
-func (c Checksums) CompareWithPkg(pkg *cloudsmith_api.Package) error {
+func (c Checksums) CompareWithPkg(pkg *cloudsmithapi.PackageDetail) error {
 	var errs []error
 
 	if c.MD5 != pkg.GetChecksumMd5() {
@@ -52,8 +52,7 @@ func (c Checksums) CompareWithPkg(pkg *cloudsmith_api.Package) error {
 }
 
 func checksumMismatchError(localChecksum string, remoteChecksum string, checksumType string) string {
-	formatString := fmt.Sprintf("Checksum mismatch (%s): expected=%s, got=%s", localChecksum, remoteChecksum, checksumType)
-	return formatString
+	return fmt.Sprintf("Checksum mismatch (%s): expected=%s, got=%s", checksumType, localChecksum, remoteChecksum)
 }
 
 func dataSourcePackageRead(d *schema.ResourceData, m interface{}) error {

--- a/cloudsmith/data_source_usage_limits.go
+++ b/cloudsmith/data_source_usage_limits.go
@@ -1,0 +1,66 @@
+package cloudsmith
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceUsageLimits() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceUsageLimitsRead,
+
+		Schema: map[string]*schema.Schema{
+			usageLimitsOrganization: {
+				Type:         schema.TypeString,
+				Description:  "The slug of the Cloudsmith organization whose usage limits are read.",
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			usageLimitsAllowOpenSourceOverage: {
+				Type:        schema.TypeBool,
+				Description: "Whether on-demand open source usage is allowed.",
+				Computed:    true,
+			},
+			usageLimitsBandwidthOverageLimit: {
+				Type:        schema.TypeInt,
+				Description: "The package delivery on-demand limit in GB.",
+				Computed:    true,
+			},
+			usageLimitsStorageOverageLimit: {
+				Type:        schema.TypeInt,
+				Description: "The artifact data on-demand limit in GB.",
+				Computed:    true,
+			},
+			usageLimitsBandwidthMaximum: {
+				Type:        schema.TypeInt,
+				Description: "The maximum package delivery overage allowed by the organization's plan, in GB.",
+				Computed:    true,
+			},
+			usageLimitsStorageMaximum: {
+				Type:        schema.TypeInt,
+				Description: "The maximum artifact data overage allowed by the organization's plan, in GB.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceUsageLimitsRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+	organization := requiredString(d, usageLimitsOrganization)
+
+	limits, _, err := pc.APIClient.OrgsApi.OrgsRetrieveUsageLimits(pc.Auth, organization).Execute()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error reading usage limits for organization %q: %w", organization, formatAPIError(err)))
+	}
+
+	if err := setUsageLimitsFields(d, organization, limits); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(organization)
+	return nil
+}

--- a/cloudsmith/data_source_usage_limits_test.go
+++ b/cloudsmith/data_source_usage_limits_test.go
@@ -1,0 +1,85 @@
+package cloudsmith
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cloudsmithapi "github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestDataSourceUsageLimitsSchema(t *testing.T) {
+	t.Parallel()
+
+	dataSource := dataSourceUsageLimits()
+	if !dataSource.Schema[usageLimitsOrganization].Required {
+		t.Fatal("expected organization to be required")
+	}
+	for _, name := range []string{
+		usageLimitsAllowOpenSourceOverage,
+		usageLimitsBandwidthOverageLimit,
+		usageLimitsStorageOverageLimit,
+		usageLimitsBandwidthMaximum,
+		usageLimitsStorageMaximum,
+	} {
+		if !dataSource.Schema[name].Computed {
+			t.Fatalf("expected %q to be computed", name)
+		}
+	}
+}
+
+func TestDataSourceUsageLimitsRead(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/orgs/example-org/usage-limits/" {
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"allow_open_source_overage":true,"bandwidth_overage_limit":100,"storage_overage_limit":50,"bandwidth_maximum":200,"storage_maximum":150}`)
+	}))
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, dataSourceUsageLimits().Schema, map[string]interface{}{
+		usageLimitsOrganization: "example-org",
+	})
+	diagnostics := dataSourceUsageLimitsRead(context.Background(), d, usageLimitsTestProviderConfig(server.URL))
+	if diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+
+	assertUsageLimitsState(t, d)
+}
+
+func usageLimitsTestProviderConfig(serverURL string) *providerConfig {
+	config := cloudsmithapi.NewConfiguration()
+	config.Servers = cloudsmithapi.ServerConfigurations{{URL: serverURL}}
+	return &providerConfig{
+		Auth:      context.Background(),
+		APIClient: cloudsmithapi.NewAPIClient(config),
+	}
+}
+
+func assertUsageLimitsState(t *testing.T, d *schema.ResourceData) {
+	t.Helper()
+
+	expected := map[string]interface{}{
+		usageLimitsAllowOpenSourceOverage: true,
+		usageLimitsBandwidthOverageLimit:  100,
+		usageLimitsStorageOverageLimit:    50,
+		usageLimitsBandwidthMaximum:       200,
+		usageLimitsStorageMaximum:         150,
+	}
+	for name, want := range expected {
+		if got := d.Get(name); got != want {
+			t.Errorf("unexpected %s: got %v, want %v", name, got, want)
+		}
+	}
+	if d.Id() != "example-org" {
+		t.Errorf("unexpected ID: got %q, want %q", d.Id(), "example-org")
+	}
+}

--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -54,6 +54,7 @@ func Provider() *schema.Provider {
 			"cloudsmith_team_members":              dataSourceTeamMembers(),
 			"cloudsmith_service_list":              dataSourceServiceList(),
 			"cloudsmith_service_details":           dataSourceServiceDetails(),
+			"cloudsmith_usage_limits":              dataSourceUsageLimits(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudsmith_entitlement":               resourceEntitlement(),
@@ -76,6 +77,7 @@ func Provider() *schema.Provider {
 			"cloudsmith_saml_auth":                 resourceSAMLAuth(),
 			"cloudsmith_repository_retention_rule": resourceRepoRetentionRule(),
 			"cloudsmith_entitlement_control":       resourceEntitlementControl(),
+			"cloudsmith_usage_limits":              resourceUsageLimits(),
 		},
 	}
 

--- a/cloudsmith/resource_usage_limits.go
+++ b/cloudsmith/resource_usage_limits.go
@@ -1,0 +1,162 @@
+package cloudsmith
+
+import (
+	"context"
+	"fmt"
+
+	cloudsmithapi "github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	usageLimitsOrganization           = "organization"
+	usageLimitsAllowOpenSourceOverage = "allow_open_source_overage"
+	usageLimitsBandwidthOverageLimit  = "bandwidth_overage_limit"
+	usageLimitsStorageOverageLimit    = "storage_overage_limit"
+	usageLimitsBandwidthMaximum       = "bandwidth_maximum"
+	usageLimitsStorageMaximum         = "storage_maximum"
+)
+
+func resourceUsageLimits() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUsageLimitsCreate,
+		ReadContext:   resourceUsageLimitsRead,
+		UpdateContext: resourceUsageLimitsUpdate,
+		DeleteContext: resourceUsageLimitsDelete,
+
+		Importer: &schema.ResourceImporter{StateContext: resourceUsageLimitsImport},
+
+		Schema: map[string]*schema.Schema{
+			usageLimitsOrganization: {
+				Type:         schema.TypeString,
+				Description:  "The slug of the Cloudsmith organization whose usage limits are managed.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			usageLimitsAllowOpenSourceOverage: {
+				Type:        schema.TypeBool,
+				Description: "Whether on-demand open source usage is allowed.",
+				Required:    true,
+			},
+			usageLimitsBandwidthOverageLimit: {
+				Type:         schema.TypeInt,
+				Description:  "The package delivery on-demand limit in GB.",
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			usageLimitsStorageOverageLimit: {
+				Type:         schema.TypeInt,
+				Description:  "The artifact data on-demand limit in GB.",
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			usageLimitsBandwidthMaximum: {
+				Type:        schema.TypeInt,
+				Description: "The maximum package delivery overage allowed by the organization's plan, in GB.",
+				Computed:    true,
+			},
+			usageLimitsStorageMaximum: {
+				Type:        schema.TypeInt,
+				Description: "The maximum artifact data overage allowed by the organization's plan, in GB.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceUsageLimitsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if diags := updateUsageLimits(d, m); diags != nil {
+		return diags
+	}
+
+	d.SetId(requiredString(d, usageLimitsOrganization))
+	return resourceUsageLimitsRead(ctx, d, m)
+}
+
+func resourceUsageLimitsRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+	organization := requiredString(d, usageLimitsOrganization)
+
+	limits, response, err := pc.APIClient.OrgsApi.OrgsRetrieveUsageLimits(pc.Auth, organization).Execute()
+	if err != nil {
+		if is404(response) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading usage limits for organization %q: %w", organization, formatAPIError(err)))
+	}
+
+	if err := setUsageLimitsFields(d, organization, limits); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(organization)
+
+	return nil
+}
+
+func setUsageLimitsFields(d *schema.ResourceData, organization string, limits *cloudsmithapi.OrgsRetrieveUsageLimits200Response) error {
+	fields := map[string]interface{}{
+		usageLimitsOrganization:           organization,
+		usageLimitsAllowOpenSourceOverage: limits.GetAllowOpenSourceOverage(),
+		usageLimitsBandwidthOverageLimit:  limits.GetBandwidthOverageLimit(),
+		usageLimitsStorageOverageLimit:    limits.GetStorageOverageLimit(),
+		usageLimitsBandwidthMaximum:       limits.GetBandwidthMaximum(),
+		usageLimitsStorageMaximum:         limits.GetStorageMaximum(),
+	}
+
+	for name, value := range fields {
+		if err := d.Set(name, value); err != nil {
+			return fmt.Errorf("error setting usage limits field %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func resourceUsageLimitsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if diags := updateUsageLimits(d, m); diags != nil {
+		return diags
+	}
+
+	return resourceUsageLimitsRead(ctx, d, m)
+}
+
+func updateUsageLimits(d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+	organization := requiredString(d, usageLimitsOrganization)
+
+	request := cloudsmithapi.NewOrganizationUsageUpdateRequestPatch()
+	request.SetAllowOpenSourceOverage(d.Get(usageLimitsAllowOpenSourceOverage).(bool))
+	request.SetBandwidthOverageLimit(int64(d.Get(usageLimitsBandwidthOverageLimit).(int)))
+	request.SetStorageOverageLimit(int64(d.Get(usageLimitsStorageOverageLimit).(int)))
+
+	_, _, err := pc.APIClient.OrgsApi.OrgsUpdateUsageLimits(pc.Auth, organization).Data(*request).Execute()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating usage limits for organization %q: %w", organization, formatAPIError(err)))
+	}
+
+	return nil
+}
+
+func resourceUsageLimitsDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// Cloudsmith always has a usage-limits configuration for an organization and
+	// the API has no delete/reset operation. Forget the Terraform resource without
+	// changing the organization's live settings.
+	d.SetId("")
+	return nil
+}
+
+func resourceUsageLimitsImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	organization := d.Id()
+	if organization == "" {
+		return nil, fmt.Errorf("usage limits import ID must be an organization slug")
+	}
+
+	if err := d.Set(usageLimitsOrganization, organization); err != nil {
+		return nil, fmt.Errorf("error setting organization during usage limits import: %w", err)
+	}
+	d.SetId(organization)
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudsmith/resource_usage_limits_test.go
+++ b/cloudsmith/resource_usage_limits_test.go
@@ -1,0 +1,227 @@
+package cloudsmith
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestResourceUsageLimitsCreate(t *testing.T) {
+	t.Parallel()
+
+	var patchBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/orgs/example-org/usage-limits/" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPatch:
+			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			fmt.Fprint(w, `{"allow_open_source_overage":true,"bandwidth_overage_limit":100,"storage_overage_limit":50}`)
+		case http.MethodGet:
+			fmt.Fprint(w, `{"allow_open_source_overage":true,"bandwidth_overage_limit":100,"storage_overage_limit":50,"bandwidth_maximum":200,"storage_maximum":150}`)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, resourceUsageLimits().Schema, map[string]interface{}{
+		usageLimitsOrganization:           "example-org",
+		usageLimitsAllowOpenSourceOverage: true,
+		usageLimitsBandwidthOverageLimit:  100,
+		usageLimitsStorageOverageLimit:    50,
+	})
+	diagnostics := resourceUsageLimitsCreate(context.Background(), d, usageLimitsTestProviderConfig(server.URL))
+	if diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+
+	expectedPatch := map[string]interface{}{
+		"allow_open_source_overage": true,
+		"bandwidth_overage_limit":   float64(100),
+		"storage_overage_limit":     float64(50),
+	}
+	for name, want := range expectedPatch {
+		if got := patchBody[name]; got != want {
+			t.Errorf("unexpected PATCH field %s: got %v, want %v", name, got, want)
+		}
+	}
+	assertUsageLimitsState(t, d)
+}
+
+func TestResourceUsageLimitsSchema(t *testing.T) {
+	t.Parallel()
+
+	resource := resourceUsageLimits()
+
+	for _, name := range []string{
+		usageLimitsOrganization,
+		usageLimitsAllowOpenSourceOverage,
+		usageLimitsBandwidthOverageLimit,
+		usageLimitsStorageOverageLimit,
+	} {
+		if !resource.Schema[name].Required {
+			t.Fatalf("expected %q to be required", name)
+		}
+	}
+
+	for _, name := range []string{usageLimitsBandwidthMaximum, usageLimitsStorageMaximum} {
+		if !resource.Schema[name].Computed {
+			t.Fatalf("expected %q to be computed", name)
+		}
+	}
+
+	for _, name := range []string{usageLimitsBandwidthOverageLimit, usageLimitsStorageOverageLimit} {
+		if warnings, errors := resource.Schema[name].ValidateFunc(-1, name); len(warnings) != 0 || len(errors) == 0 {
+			t.Fatalf("expected %q to reject a negative value", name)
+		}
+		if warnings, errors := resource.Schema[name].ValidateFunc(0, name); len(warnings) != 0 || len(errors) != 0 {
+			t.Fatalf("expected %q to accept zero, warnings: %v, errors: %v", name, warnings, errors)
+		}
+	}
+}
+
+func TestResourceUsageLimitsImport(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, resourceUsageLimits().Schema, nil)
+	d.SetId("example-org")
+
+	resources, err := resourceUsageLimitsImport(context.Background(), d, nil)
+	if err != nil {
+		t.Fatalf("unexpected import error: %v", err)
+	}
+	if got := resources[0].Get(usageLimitsOrganization); got != "example-org" {
+		t.Fatalf("expected imported organization to be example-org, got %q", got)
+	}
+}
+
+func TestResourceUsageLimitsDeleteOnlyClearsState(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, resourceUsageLimits().Schema, nil)
+	d.SetId("example-org")
+
+	if diags := resourceUsageLimitsDelete(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected delete diagnostics: %v", diags)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected resource ID to be cleared, got %q", d.Id())
+	}
+}
+
+func TestAccUsageLimits_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUsageLimitsCheckDestroy("cloudsmith_usage_limits.test"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsageLimitsConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUsageLimitsCheckExists("cloudsmith_usage_limits.test"),
+					resource.TestCheckResourceAttr("cloudsmith_usage_limits.test", "allow_open_source_overage", "false"),
+					resource.TestCheckResourceAttr("cloudsmith_usage_limits.test", "bandwidth_overage_limit", "0"),
+					resource.TestCheckResourceAttr("cloudsmith_usage_limits.test", "storage_overage_limit", "0"),
+					resource.TestCheckResourceAttrSet("cloudsmith_usage_limits.test", "bandwidth_maximum"),
+					resource.TestCheckResourceAttrSet("cloudsmith_usage_limits.test", "storage_maximum"),
+				),
+			},
+			{
+				Config: testAccUsageLimitsConfigOpenSourceOverage,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUsageLimitsCheckExists("cloudsmith_usage_limits.test"),
+					resource.TestCheckResourceAttr("cloudsmith_usage_limits.test", "allow_open_source_overage", "true"),
+				),
+			},
+			{
+				ResourceName: "cloudsmith_usage_limits.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return os.Getenv("CLOUDSMITH_NAMESPACE"), nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// testAccUsageLimitsCheckDestroy asserts the destroy behaviour of this
+// resource: Cloudsmith has no delete or reset operation for usage limits, so a
+// destroy only drops Terraform state and the organization's settings must
+// remain readable afterwards.
+func testAccUsageLimitsCheckDestroy(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+		organization := resourceState.Primary.Attributes["organization"]
+
+		if _, _, err := pc.APIClient.OrgsApi.OrgsRetrieveUsageLimits(pc.Auth, organization).Execute(); err != nil {
+			return fmt.Errorf("error reading usage limits after destroy: %w", formatAPIError(err))
+		}
+
+		return nil
+	}
+}
+
+func testAccUsageLimitsCheckExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		pc := testAccProvider.Meta().(*providerConfig)
+		organization := resourceState.Primary.Attributes["organization"]
+
+		if _, _, err := pc.APIClient.OrgsApi.OrgsRetrieveUsageLimits(pc.Auth, organization).Execute(); err != nil {
+			return fmt.Errorf("error checking usage limits existence: %w", formatAPIError(err))
+		}
+
+		return nil
+	}
+}
+
+// Overage limits are kept at zero because the accepted range depends on the
+// organization's plan maximums and its current overage usage, neither of which
+// is known ahead of the test run.
+var testAccUsageLimitsConfigBasic = strings.TrimSpace(fmt.Sprintf(`
+resource "cloudsmith_usage_limits" "test" {
+    organization              = "%s"
+    allow_open_source_overage = false
+    bandwidth_overage_limit   = 0
+    storage_overage_limit     = 0
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE")))
+
+var testAccUsageLimitsConfigOpenSourceOverage = strings.TrimSpace(fmt.Sprintf(`
+resource "cloudsmith_usage_limits" "test" {
+    organization              = "%s"
+    allow_open_source_overage = true
+    bandwidth_overage_limit   = 0
+    storage_overage_limit     = 0
+}
+`, os.Getenv("CLOUDSMITH_NAMESPACE")))

--- a/docs/data-sources/usage_limits.md
+++ b/docs/data-sources/usage_limits.md
@@ -1,0 +1,33 @@
+# Usage Limits Data Source
+
+The usage limits data source reads the current on-demand usage settings and plan-specific maximum values for a Cloudsmith organization without managing them.
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+  api_key = "my-api-key"
+}
+
+data "cloudsmith_usage_limits" "example" {
+  organization = "my-organization"
+}
+
+output "package_delivery_limit" {
+  value = data.cloudsmith_usage_limits.example.bandwidth_overage_limit
+}
+```
+
+## Argument Reference
+
+* `organization` - (Required) The organization slug.
+
+## Attribute Reference
+
+* `allow_open_source_overage` - Whether on-demand open source usage is allowed.
+* `bandwidth_overage_limit` - The Package Delivery On-Demand Limit, in GB.
+* `storage_overage_limit` - The Artifact Data On-Demand Limit, in GB.
+* `bandwidth_maximum` - The maximum package delivery overage allowed by the organization's plan, in GB.
+* `storage_maximum` - The maximum artifact data overage allowed by the organization's plan, in GB.
+
+To manage these settings, use the [`cloudsmith_usage_limits` resource](../resources/usage_limits.md).

--- a/docs/resources/usage_limits.md
+++ b/docs/resources/usage_limits.md
@@ -1,0 +1,46 @@
+# Usage Limits Resource
+
+The usage limits resource manages the on-demand package delivery and artifact data limits for a Cloudsmith organization, including whether on-demand open source usage is allowed.
+
+**Note: Cloudsmith does not provide an API operation to delete or reset usage limits. Destroying this resource removes it from Terraform state and leaves the organization's current settings unchanged.**
+
+## Example Usage
+
+```hcl
+provider "cloudsmith" {
+  api_key = "my-api-key"
+}
+
+resource "cloudsmith_usage_limits" "example" {
+  organization              = "my-organization"
+  bandwidth_overage_limit   = 100
+  storage_overage_limit     = 50
+  allow_open_source_overage = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) The organization slug. Changing this value creates a new resource.
+* `bandwidth_overage_limit` - (Required) Package Delivery On-Demand Limit, in GB. Must be zero or greater, no higher than `bandwidth_maximum`, and no lower than current package delivery overage usage.
+* `storage_overage_limit` - (Required) Artifact Data On-Demand Limit, in GB. Must be zero or greater, no higher than `storage_maximum`, and no lower than current artifact data overage usage.
+* `allow_open_source_overage` - (Required) Whether to allow on-demand open source usage.
+
+## Attribute Reference
+
+In addition to the arguments above, the following attributes are exported:
+
+* `bandwidth_maximum` - The maximum package delivery overage allowed by the organization's plan, in GB.
+* `storage_maximum` - The maximum artifact data overage allowed by the organization's plan, in GB.
+
+## Import
+
+Usage limits can be imported using the organization slug:
+
+```shell
+terraform import cloudsmith_usage_limits.example my-organization
+```
+
+To inspect an organization's usage limits without managing them, use the [`cloudsmith_usage_limits` data source](../data-sources/usage_limits.md).

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsmith-io/terraform-provider-cloudsmith
 go 1.26
 
 require (
-	github.com/cloudsmith-io/cloudsmith-api-go v0.0.59
+	github.com/cloudsmith-io/cloudsmith-api-go v0.0.60
 	github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.59 h1:KdAwf2TDawdg4zOGucDJ91ebGZwkLV1gBH0plq/g4a4=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.59/go.mod h1:xHTDgU8TyMXiWUZdn2OQR7AaZdz9M5SrNenyQU44zGQ=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.60 h1:H1qn16Se4vOKoqaD0yYlI/8/DHMfqEBO6I3Ky6ejBxo=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.60/go.mod h1:xHTDgU8TyMXiWUZdn2OQR7AaZdz9M5SrNenyQU44zGQ=
 github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523 h1:zpwbcGnLwreE18qP6lYD5z9s36BZF/4va1Rc3tApgyQ=
 github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523/go.mod h1:yjFP2n2rHMRsL44JdJUqh+iEWqHKrbttEmDyIGllVDY=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=


### PR DESCRIPTION
# Description

Organization usage limits could only be changed in the UI. `cloudsmith-api-go` v0.0.60 exposes `GET/PATCH /orgs/{org}/usage-limits/`, so they can now be managed as Terraform state.

Adds a `cloudsmith_usage_limits` resource for the package delivery and artifact data on-demand limits plus the open source overage setting, and a matching data source for reading those values (including the plan-specific maximums) without managing them. Import works from the organization slug.

```hcl
resource "cloudsmith_usage_limits" "example" {
  organization              = "my-organization"
  bandwidth_overage_limit   = 100
  storage_overage_limit     = 50
  allow_open_source_overage = true
}

data "cloudsmith_usage_limits" "example" {
  organization = "my-organization"
}

# Plan maximums are read-only and come from the organization's plan.
output "package_delivery_headroom" {
  value = data.cloudsmith_usage_limits.example.bandwidth_maximum - data.cloudsmith_usage_limits.example.bandwidth_overage_limit
}
```

Cloudsmith has no delete or reset operation for usage limits, so destroy is state-only:

```console
$ terraform destroy
cloudsmith_usage_limits.example: Destroying... [id=my-organization]
cloudsmith_usage_limits.example: Destruction complete after 0s

$ terraform import cloudsmith_usage_limits.example my-organization
cloudsmith_usage_limits.example: Importing from ID "my-organization"...
cloudsmith_usage_limits.example: Import successful!

# The re-imported state still shows 100/50: destroy dropped state only, the
# organization's live limits were never changed.
```

The generated client bump also changes the type returned by the existing package read endpoint from `Package` to `PackageDetail`. `Checksums.CompareWithPkg` now takes `*PackageDetail` directly; `Package` is no longer referenced anywhere in the provider.

Closes #161.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Tests
- [ ] Other (please describe)

## Testing

- Unit tests cover the resource and data source against a mock API server, plus schema, import, and the state-only delete.
- Tested locally against internal org

## Additional Notes

- Drive-by fix: `checksumMismatchError` passed its arguments in the wrong order for its format string, so a checksum mismatch printed the local checksum where the algorithm name belonged and the algorithm name in `got=`. Unrelated to usage limits, but it made the existing package download error unreadable.
