### PR TITLE
fix: stabilize team members acceptance test

### DIFF
--- a/cloudsmith/data_source_team_members.go
+++ b/cloudsmith/data_source_team_members.go
@@ -17,7 +17,7 @@ func dataSourceTeamMembersRead(d *schema.ResourceData, m interface{}) error {
 	teamName := requiredString(d, "team_name")
 
 	var teamMembers *cloudsmith.OrganizationTeamMembers
-	err := waiter(func() error {
+	readTeamMembers := func() error {
 		req := pc.APIClient.OrgsApi.OrgsTeamsMembersList(pc.Auth, organization, teamName)
 		members, resp, err := pc.APIClient.OrgsApi.OrgsTeamsMembersListExecute(req)
 		if err != nil {
@@ -28,7 +28,18 @@ func dataSourceTeamMembersRead(d *schema.ResourceData, m interface{}) error {
 		}
 		teamMembers = members
 		return nil
-	}, defaultCreationTimeout, defaultCreationInterval)
+	}
+
+	// Most reads are immediately consistent and should not incur waiter's initial delay.
+	err := readTeamMembers()
+	if err == errKeepWaiting {
+		err = waiter(readTeamMembers, defaultCreationTimeout, defaultCreationInterval)
+		if err == errTimedOut {
+			// Preserve the data-source behavior for an organization or team that does not exist.
+			d.SetId("")
+			return nil
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("error retrieving team members for %s/%s: %w", organization, teamName, err)
 	}

--- a/cloudsmith/data_source_team_members.go
+++ b/cloudsmith/data_source_team_members.go
@@ -16,13 +16,19 @@ func dataSourceTeamMembersRead(d *schema.ResourceData, m interface{}) error {
 	organization := requiredString(d, "organization")
 	teamName := requiredString(d, "team_name")
 
-	req := pc.APIClient.OrgsApi.OrgsTeamsMembersList(pc.Auth, organization, teamName)
-	teamMembers, resp, err := pc.APIClient.OrgsApi.OrgsTeamsMembersListExecute(req)
-	if is404(resp) {
-		// If either org or team not found, clear state
-		d.SetId("")
+	var teamMembers *cloudsmith.OrganizationTeamMembers
+	err := waiter(func() error {
+		req := pc.APIClient.OrgsApi.OrgsTeamsMembersList(pc.Auth, organization, teamName)
+		members, resp, err := pc.APIClient.OrgsApi.OrgsTeamsMembersListExecute(req)
+		if err != nil {
+			if is404(resp) {
+				return errKeepWaiting
+			}
+			return err
+		}
+		teamMembers = members
 		return nil
-	}
+	}, defaultCreationTimeout, defaultCreationInterval)
 	if err != nil {
 		return fmt.Errorf("error retrieving team members for %s/%s: %w", organization, teamName, err)
 	}

--- a/cloudsmith/data_source_team_members_test.go
+++ b/cloudsmith/data_source_team_members_test.go
@@ -5,21 +5,23 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // TestAccDataSourceTeamMembers_basic validates that team members are listed with expected fields.
 func TestAccDataSourceTeamMembers_basic(t *testing.T) {
 	t.Parallel()
+	teamName := acctest.RandomWithPrefix("terraform-acc-test-team-members")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceTeamMembersConfig(),
+				Config: testAccDataSourceTeamMembersConfig(teamName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudsmith_team_members.test", "team_name", "terraform-acc-test-team-members"),
+					resource.TestCheckResourceAttr("data.cloudsmith_team_members.test", "team_name", teamName),
 					resource.TestCheckResourceAttrSet("data.cloudsmith_team_members.test", "members.0.user"),
 					resource.TestCheckResourceAttrSet("data.cloudsmith_team_members.test", "members.0.role"),
 				),
@@ -28,10 +30,10 @@ func TestAccDataSourceTeamMembers_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceTeamMembersConfig() string {
+func testAccDataSourceTeamMembersConfig(teamName string) string {
 	return fmt.Sprintf(`
 resource "cloudsmith_team" "example" {
-  name         = "terraform-acc-test-team-members"
+  name         = %q
   organization = "%s"
   description  = "Acceptance test team members"
   visibility   = "Visible"
@@ -42,5 +44,5 @@ data "cloudsmith_team_members" "test" {
   team_name    = cloudsmith_team.example.name
   depends_on   = [cloudsmith_team.example]
 }
-`, os.Getenv("CLOUDSMITH_NAMESPACE"), os.Getenv("CLOUDSMITH_NAMESPACE"))
+`, teamName, os.Getenv("CLOUDSMITH_NAMESPACE"), os.Getenv("CLOUDSMITH_NAMESPACE"))
 }

--- a/cloudsmith/data_source_team_members_test.go
+++ b/cloudsmith/data_source_team_members_test.go
@@ -12,7 +12,7 @@ import (
 // TestAccDataSourceTeamMembers_basic validates that team members are listed with expected fields.
 func TestAccDataSourceTeamMembers_basic(t *testing.T) {
 	t.Parallel()
-	teamName := acctest.RandomWithPrefix("terraform-acc-test-team-members")
+	teamName := acctest.RandomWithPrefix("tfacc-team-members")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
# Description

`TestAccDataSourceTeamMembers_basic` could read a new team before Cloudsmith had made its membership endpoint available. The data source now retries temporary 404 responses during that propagation window. The acceptance test also uses a unique team name with a prefix short enough to stay within the API limit.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Tests
- [ ] Other (please describe)

## Testing

```bash
go test ./...
```

## Additional Notes

This fix is separate from the OIDC work so the acceptance workflow can run without another feature branch changing the same shared test organization.
