### PR TITLE
feat: add HCP Terraform OIDC authentication

### DIFF
--- a/cloudsmith/data_source_package.go
+++ b/cloudsmith/data_source_package.go
@@ -146,7 +146,11 @@ func downloadPackage(downloadUrl string, downloadDir string, pc *providerConfig,
 		return "", err
 	}
 
-	req.Header.Add("Authorization", fmt.Sprintf("Token %s", pc.GetAPIKey()))
+	apiKey, err := pc.GetAPIKey()
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Token %s", apiKey))
 
 	client := pc.APIClient.GetConfig().HTTPClient
 	if bustCache {

--- a/cloudsmith/data_source_package_test.go
+++ b/cloudsmith/data_source_package_test.go
@@ -143,7 +143,11 @@ func uploadPackage(pc *providerConfig, repository string, republish bool) error 
 		return err
 	}
 
-	request.SetBasicAuth("token", pc.GetAPIKey())
+	apiKey, err := pc.GetAPIKey()
+	if err != nil {
+		return err
+	}
+	request.SetBasicAuth("token", apiKey)
 	for k, v := range initResponse.GetUploadHeaders() {
 		request.Header.Set(k, v.(string))
 	}

--- a/cloudsmith/data_source_policy_list_test.go
+++ b/cloudsmith/data_source_policy_list_test.go
@@ -68,7 +68,7 @@ func TestPolicyListDataSource_ReturnsInitialListError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	pc, diags := newProviderConfig(server.URL, "valid-token", map[string]interface{}{}, "test-agent")
+	pc, diags := newProviderConfig(context.Background(), server.URL, staticToken("valid-token"), map[string]interface{}{}, "test-agent")
 	if diags.HasError() {
 		t.Fatalf("unexpected provider config diagnostics: %v", diags)
 	}
@@ -138,7 +138,7 @@ func TestPolicyListDataSource_PaginatesAcrossAllPages(t *testing.T) {
 	}))
 	defer server.Close()
 
-	pc, diags := newProviderConfig(server.URL, "valid-token", map[string]interface{}{}, "test-agent")
+	pc, diags := newProviderConfig(context.Background(), server.URL, staticToken("valid-token"), map[string]interface{}{}, "test-agent")
 	if diags.HasError() {
 		t.Fatalf("unexpected provider config diagnostics: %v", diags)
 	}

--- a/cloudsmith/provider.go
+++ b/cloudsmith/provider.go
@@ -4,6 +4,7 @@ package cloudsmith
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -15,11 +16,34 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {
-				Type:        schema.TypeString,
-				Description: "The API key for authenticating with the Cloudsmith API.",
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CLOUDSMITH_API_KEY", nil),
-				Sensitive:   true,
+				Type:          schema.TypeString,
+				Description:   "The API key for authenticating with the Cloudsmith API. Conflicts with oidc. When oidc is unset and CLOUDSMITH_USE_OIDC is not set, the provider reads CLOUDSMITH_API_KEY.",
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"oidc"},
+			},
+			"oidc": {
+				Type:          schema.TypeList,
+				Description:   "OIDC login using an HCP Terraform workload identity token. The identity token comes from the workspace environment (TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH or TFC_WORKLOAD_IDENTITY_TOKEN), not this block. Conflicts with api_key. Ignores leftover CLOUDSMITH_API_KEY. You can enable the same path with CLOUDSMITH_USE_OIDC=true and no block.",
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"api_key"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"organization": {
+							Type:        schema.TypeString,
+							Description: "Cloudsmith organization slug. Defaults to CLOUDSMITH_ORG when unset.",
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("CLOUDSMITH_ORG", nil),
+						},
+						"service_slug": {
+							Type:        schema.TypeString,
+							Description: "OIDC service account slug. Defaults to CLOUDSMITH_SERVICE_SLUG when unset.",
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("CLOUDSMITH_SERVICE_SLUG", nil),
+						},
+					},
+				},
 			},
 			"api_host": {
 				Type:        schema.TypeString,
@@ -81,7 +105,7 @@ func Provider() *schema.Provider {
 		},
 	}
 
-	p.ConfigureContextFunc = func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	p.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		terraformVersion := p.TerraformVersion
 		if terraformVersion == "" {
 			// Terraform 0.12 introduced this field to the protocol
@@ -90,11 +114,19 @@ func Provider() *schema.Provider {
 		}
 
 		apiHost := requiredString(d, "api_host")
-		apiKey := requiredString(d, "api_key")
 		userAgent := fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, terraformVersion)
 		headers := d.Get("headers").(map[string]interface{})
 
-		return newProviderConfig(apiHost, apiKey, headers, userAgent)
+		cred, err := parseCredential(authSpecFromResourceData(d), os.Getenv)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+		tokens, err := tokenSourceFromCredential(cred, apiHost, headers, userAgent, os.Getenv, nil)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
+		return newProviderConfig(ctx, apiHost, tokens, headers, userAgent)
 	}
 
 	return p

--- a/cloudsmith/provider_auth.go
+++ b/cloudsmith/provider_auth.go
@@ -1,0 +1,320 @@
+package cloudsmith
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloudsmith-io/cloudsmith-api-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	tokenRefreshSkew    = time.Minute
+	opaqueTokenLifetime = 15 * time.Minute
+	oidcHTTPTimeout     = 30 * time.Second
+)
+
+var (
+	errMixedCredentials   = errors.New("api_key and oidc cannot be set together")
+	errMissingCredentials = errors.New("set api_key, an oidc block, or CLOUDSMITH_USE_OIDC")
+	errMissingOIDCToken   = errors.New(
+		"oidc requires an HCP Terraform workload identity token in TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH " +
+			"or TFC_WORKLOAD_IDENTITY_TOKEN; set TFC_WORKLOAD_IDENTITY_AUDIENCE (or " +
+			"TFC_WORKLOAD_IDENTITY_AUDIENCE_CLOUDSMITH) as an environment variable on the workspace so HCP " +
+			"Terraform injects one",
+	)
+	errIncompleteOIDC     = errors.New("oidc requires organization and service_slug (set the attributes or CLOUDSMITH_ORG and CLOUDSMITH_SERVICE_SLUG)")
+	errEmptyExchangeToken = errors.New("OIDC token exchange returned an empty token")
+	errInvalidCredential  = errors.New("invalid credential")
+	errInvalidAPIHost     = errors.New("api_host must be an absolute URL")
+)
+
+// tokenSource hands the HTTP transport a Cloudsmith credential. The static
+// api_key path and the OIDC path both go through it, so the transport does not
+// need to know which one is in use.
+type tokenSource interface {
+	Token(ctx context.Context) (string, error)
+	invalidate(used string)
+	canRetryAuth() bool
+}
+
+type staticToken string
+
+func (s staticToken) Token(context.Context) (string, error) { return string(s), nil }
+func (s staticToken) invalidate(string)                     {}
+func (s staticToken) canRetryAuth() bool                    { return false }
+
+type oidcTokenSource struct {
+	mu        sync.Mutex
+	cached    string
+	expiry    time.Time
+	identity  oidcIdentity
+	apiHost   string
+	headers   map[string]interface{}
+	userAgent string
+	getenv    func(string) string
+	now       func() time.Time
+}
+
+func (s *oidcTokenSource) canRetryAuth() bool { return true }
+
+// invalidate drops the cached token only when it is still the one the caller
+// used. Without that check, N requests failing a 401 in parallel would each
+// discard the token a sibling had already refreshed, forcing N exchanges.
+func (s *oidcTokenSource) invalidate(used string) {
+	s.mu.Lock()
+	if used == "" || s.cached == used {
+		s.cached = ""
+		s.expiry = time.Time{}
+	}
+	s.mu.Unlock()
+}
+
+func (s *oidcTokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	if s.cached != "" && now.Add(tokenRefreshSkew).Before(s.expiry) {
+		return s.cached, nil
+	}
+	assertion, err := loadAssertion(s.getenv)
+	if err != nil {
+		return "", err
+	}
+	token, err := exchangeOIDC(ctx, s.apiHost, s.headers, s.userAgent, s.identity, assertion)
+	if err != nil {
+		return "", err
+	}
+	s.cached = token
+	s.expiry = jwtExpiry(token)
+	if s.expiry.IsZero() {
+		// The exchange returned something we cannot read an exp from. Refresh on
+		// a timer rather than caching forever: a token with no readable expiry
+		// would otherwise only ever be replaced by a 401.
+		s.expiry = now.Add(opaqueTokenLifetime)
+	}
+	return token, nil
+}
+
+type credential struct {
+	static *string
+	oidc   *oidcIdentity
+}
+
+type oidcIdentity struct {
+	organization string
+	serviceSlug  string
+}
+
+type authSpec struct {
+	apiKey string
+	oidc   *oidcBlockSpec
+}
+
+type oidcBlockSpec struct {
+	organization string
+	serviceSlug  string
+}
+
+func authSpecFromResourceData(d *schema.ResourceData) authSpec {
+	spec := authSpec{apiKey: strings.TrimSpace(requiredString(d, "api_key"))}
+	raw, ok := d.Get("oidc").([]interface{})
+	if !ok || len(raw) == 0 {
+		return spec
+	}
+	block := oidcBlockSpec{}
+	if m, ok := raw[0].(map[string]interface{}); ok && m != nil {
+		if v, ok := m["organization"].(string); ok {
+			block.organization = strings.TrimSpace(v)
+		}
+		if v, ok := m["service_slug"].(string); ok {
+			block.serviceSlug = strings.TrimSpace(v)
+		}
+	}
+	spec.oidc = &block
+	return spec
+}
+
+func envEnabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseCredential(spec authSpec, getenv func(string) string) (credential, error) {
+	oidcOn := spec.oidc != nil || envEnabled(getenv("CLOUDSMITH_USE_OIDC"))
+	// spec.apiKey is the HCL argument only: the api_key schema entry has no
+	// DefaultFunc, so a leftover CLOUDSMITH_API_KEY workspace variable does not
+	// conflict with oidc and an existing workspace can migrate as-is.
+	if oidcOn && spec.apiKey != "" {
+		return credential{}, errMixedCredentials
+	}
+	if oidcOn {
+		org := ""
+		slug := ""
+		if spec.oidc != nil {
+			org = spec.oidc.organization
+			slug = spec.oidc.serviceSlug
+		}
+		if org == "" {
+			org = strings.TrimSpace(getenv("CLOUDSMITH_ORG"))
+		}
+		if slug == "" {
+			slug = strings.TrimSpace(getenv("CLOUDSMITH_SERVICE_SLUG"))
+		}
+		if org == "" || slug == "" {
+			return credential{}, errIncompleteOIDC
+		}
+		return credential{oidc: &oidcIdentity{organization: org, serviceSlug: slug}}, nil
+	}
+	if spec.apiKey != "" {
+		key := spec.apiKey
+		return credential{static: &key}, nil
+	}
+	if key := strings.TrimSpace(getenv("CLOUDSMITH_API_KEY")); key != "" {
+		return credential{static: &key}, nil
+	}
+	return credential{}, errMissingCredentials
+}
+
+func tokenSourceFromCredential(
+	cred credential,
+	apiHost string,
+	headers map[string]interface{},
+	userAgent string,
+	getenv func(string) string,
+	now func() time.Time,
+) (tokenSource, error) {
+	switch {
+	case cred.static != nil:
+		return staticToken(*cred.static), nil
+	case cred.oidc != nil:
+		if now == nil {
+			now = time.Now
+		}
+		return &oidcTokenSource{
+			identity:  *cred.oidc,
+			apiHost:   apiHost,
+			headers:   headers,
+			userAgent: userAgent,
+			getenv:    getenv,
+			now:       now,
+		}, nil
+	default:
+		return nil, errInvalidCredential
+	}
+}
+
+// loadAssertion reads the identity token HCP Terraform injects into the run.
+// The tagged variable wins, so a workspace can keep a Cloudsmith-specific
+// audience alongside a generic one.
+func loadAssertion(getenv func(string) string) (string, error) {
+	for _, key := range []string{"TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH", "TFC_WORKLOAD_IDENTITY_TOKEN"} {
+		if v := strings.TrimSpace(getenv(key)); v != "" {
+			return v, nil
+		}
+	}
+	return "", errMissingOIDCToken
+}
+
+func exchangeOIDC(ctx context.Context, apiHost string, headers map[string]interface{}, userAgent string, id oidcIdentity, assertion string) (string, error) {
+	openIDBase, err := openIDServerURL(apiHost)
+	if err != nil {
+		return "", err
+	}
+
+	cfg := cloudsmith.NewConfiguration()
+	cfg.Debug = false
+	cfg.HTTPClient = &http.Client{
+		Timeout: oidcHTTPTimeout,
+		Transport: &headerTransport{
+			headers: headers,
+			rt:      http.DefaultTransport,
+		},
+	}
+	cfg.Servers = cloudsmith.ServerConfigurations{{URL: openIDBase}}
+	cfg.UserAgent = userAgent
+
+	client := cloudsmith.NewAPIClient(cfg)
+	out, _, err := client.OpenidApi.OpenidCreate(ctx, id.organization).
+		Data(cloudsmith.OidcRequest{
+			OidcToken:   assertion,
+			ServiceSlug: id.serviceSlug,
+		}).
+		Execute()
+	if err != nil {
+		return "", fmt.Errorf("OIDC token exchange failed: %w", err)
+	}
+	token := ""
+	if out != nil {
+		token = out.GetToken()
+	}
+	if token == "" {
+		return "", errEmptyExchangeToken
+	}
+	return token, nil
+}
+
+// openIDServerURL drops a trailing /v1 from api_host: the exchange endpoint
+// lives at the host root, not under the versioned API path.
+func openIDServerURL(apiHost string) (string, error) {
+	if apiHost == "" {
+		return "", errInvalidAPIHost
+	}
+	u, err := url.Parse(apiHost)
+	if err != nil {
+		return "", fmt.Errorf("api_host: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", errInvalidAPIHost
+	}
+
+	path := strings.TrimSuffix(u.Path, "/")
+	segments := strings.Split(path, "/")
+	if n := len(segments); n > 0 && segments[n-1] == "v1" {
+		segments = segments[:n-1]
+	}
+	u.Path = strings.Join(segments, "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	u.RawPath = ""
+
+	out := u.String()
+	if u.Path == "" || u.Path == "/" {
+		out = strings.TrimSuffix(out, "/")
+	}
+	return out, nil
+}
+
+func jwtExpiry(token string) time.Time {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return time.Time{}
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		padded, padErr := base64.URLEncoding.DecodeString(parts[1])
+		if padErr != nil {
+			return time.Time{}
+		}
+		payload = padded
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return time.Time{}
+	}
+	return time.Unix(claims.Exp, 0)
+}

--- a/cloudsmith/provider_auth_test.go
+++ b/cloudsmith/provider_auth_test.go
@@ -1,0 +1,184 @@
+package cloudsmith
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestOIDCTokenSourceCachesAndRefreshesBeforeExpiry(t *testing.T) {
+	base := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+	now := base
+	tokens := []string{
+		testJWT(t, base.Add(10*time.Minute)),
+		testJWT(t, base.Add(30*time.Minute)),
+	}
+	var exchanges atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		call := int(exchanges.Add(1))
+		if call > len(tokens) {
+			http.Error(w, "unexpected exchange", http.StatusInternalServerError)
+			return
+		}
+		writeOIDCToken(t, w, tokens[call-1])
+	}))
+	defer server.Close()
+	source := testOIDCTokenSource(server.URL+"/v1", func() time.Time { return now })
+
+	first, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("first token: %v", err)
+	}
+	second, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("cached token: %v", err)
+	}
+	if first != second || exchanges.Load() != 1 {
+		t.Fatalf("cached token = %q after %d exchanges, want %q after 1", second, exchanges.Load(), first)
+	}
+
+	now = base.Add(9 * time.Minute)
+	refreshed, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("refreshed token: %v", err)
+	}
+	if refreshed != tokens[1] || exchanges.Load() != 2 {
+		t.Fatalf("refreshed token = %q after %d exchanges, want second token after 2", refreshed, exchanges.Load())
+	}
+}
+
+func TestOIDCTokenSourceRetriesAfterFailedExchange(t *testing.T) {
+	base := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+	wantToken := testJWT(t, base.Add(10*time.Minute))
+	var exchanges atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if exchanges.Add(1) == 1 {
+			http.Error(w, "exchange failed", http.StatusBadGateway)
+			return
+		}
+		writeOIDCToken(t, w, wantToken)
+	}))
+	defer server.Close()
+	source := testOIDCTokenSource(server.URL+"/v1", func() time.Time { return base })
+
+	if _, err := source.Token(context.Background()); err == nil {
+		t.Fatal("first token exchange succeeded, want error")
+	}
+	got, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("second token exchange: %v", err)
+	}
+	if got != wantToken || exchanges.Load() != 2 {
+		t.Fatalf("token = %q after %d exchanges, want %q after 2", got, exchanges.Load(), wantToken)
+	}
+}
+
+func TestOIDCTokenSourceSerializesConcurrentRefresh(t *testing.T) {
+	base := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+	wantToken := testJWT(t, base.Add(10*time.Minute))
+	var exchanges atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		writeOIDCToken(t, w, wantToken)
+	}))
+	defer server.Close()
+	source := testOIDCTokenSource(server.URL+"/v1", func() time.Time { return base })
+
+	const callers = 12
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			token, err := source.Token(context.Background())
+			if err == nil && token != wantToken {
+				err = fmt.Errorf("token = %q, want %q", token, wantToken)
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	if exchanges.Load() != 1 {
+		t.Errorf("exchanges = %d, want 1", exchanges.Load())
+	}
+}
+
+func TestOIDCTokenSourceIgnoresConcurrentStaleInvalidation(t *testing.T) {
+	base := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+	wantToken := testJWT(t, base.Add(10*time.Minute))
+	source := &oidcTokenSource{
+		cached: wantToken,
+		expiry: base.Add(10 * time.Minute),
+		now:    func() time.Time { return base },
+	}
+
+	const callers = 12
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			source.invalidate("stale-token")
+		}()
+	}
+	wg.Wait()
+
+	got, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("token after stale invalidation: %v", err)
+	}
+	if got != wantToken {
+		t.Errorf("token = %q, want cached token %q", got, wantToken)
+	}
+}
+
+func testOIDCTokenSource(apiHost string, now func() time.Time) *oidcTokenSource {
+	return &oidcTokenSource{
+		identity: oidcIdentity{
+			organization: "test-org",
+			serviceSlug:  "test-service",
+		},
+		apiHost: apiHost,
+		getenv: func(key string) string {
+			if key == "TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH" {
+				return "workload-identity-token"
+			}
+			return ""
+		},
+		now: now,
+	}
+}
+
+func testJWT(t *testing.T, expiry time.Time) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]int64{"exp": expiry.Unix()})
+	if err != nil {
+		t.Fatalf("marshal JWT payload: %v", err)
+	}
+	return "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+func writeOIDCToken(t *testing.T, w http.ResponseWriter, token string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]string{"token": token}); err != nil {
+		t.Errorf("write OIDC response: %v", err)
+	}
+}

--- a/cloudsmith/provider_config.go
+++ b/cloudsmith/provider_config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 	cloudsmithv2 "github.com/cloudsmith-io/cloudsmith-go-v2"
@@ -39,7 +40,7 @@ func newProviderConfig(ctx context.Context, apiHost string, tokens tokenSource, 
 		return nil, diag.FromErr(errMissingCredentials)
 	}
 
-	credHost, err := credentialHost(apiHost)
+	credEndpoint, err := credentialEndpointFor(apiHost)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
@@ -48,9 +49,9 @@ func newProviderConfig(ctx context.Context, apiHost string, tokens tokenSource, 
 		Transport: logging.NewSubsystemLoggingHTTPTransport("Cloudsmith", &headerTransport{
 			headers: headers,
 			rt: &apiKeyTransport{
-				tokens:  tokens,
-				apiHost: credHost,
-				rt:      http.DefaultTransport,
+				tokens:      tokens,
+				apiEndpoint: credEndpoint,
+				rt:          http.DefaultTransport,
 			},
 		}),
 	}
@@ -126,25 +127,36 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type apiKeyTransport struct {
-	tokens  tokenSource
-	apiHost string
-	rt      http.RoundTripper
+	tokens      tokenSource
+	apiEndpoint credentialEndpoint
+	rt          http.RoundTripper
 }
 
-// credentialHost is the only host apiKeyTransport will send the Cloudsmith
-// credential to. An empty api_host yields an empty host, which disables the
-// restriction and keeps callers that pass no api_host working. A non-empty
-// api_host that is not absolute is rejected here rather than left to fail later
-// as an opaque "unsupported protocol scheme" from the round tripper.
-func credentialHost(apiHost string) (string, error) {
+type credentialEndpoint struct {
+	scheme string
+	host   string
+}
+
+// credentialEndpointFor returns the only scheme and host apiKeyTransport will
+// send the Cloudsmith credential to. An empty api_host yields an empty endpoint,
+// which disables the restriction and keeps callers that pass no api_host
+// working. A non-empty api_host that is not absolute is rejected here rather
+// than left to fail later as an opaque "unsupported protocol scheme" from the
+// round tripper.
+func credentialEndpointFor(apiHost string) (credentialEndpoint, error) {
 	if apiHost == "" {
-		return "", nil
+		return credentialEndpoint{}, nil
 	}
 	parsed, err := url.Parse(apiHost)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", errInvalidAPIHost
+		return credentialEndpoint{}, errInvalidAPIHost
 	}
-	return parsed.Host, nil
+	return credentialEndpoint{scheme: parsed.Scheme, host: parsed.Host}, nil
+}
+
+func (e credentialEndpoint) allows(u *url.URL) bool {
+	return e.host == "" ||
+		(strings.EqualFold(u.Scheme, e.scheme) && strings.EqualFold(u.Host, e.host))
 }
 
 func (t *apiKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -152,7 +164,7 @@ func (t *apiKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// and then redirect to third-party object storage. RoundTrip runs once per
 	// redirect hop, so without this check the credential would be re-stamped
 	// onto the storage host too and land in its access logs.
-	if t.apiHost != "" && req.URL.Host != t.apiHost {
+	if !t.apiEndpoint.allows(req.URL) {
 		// The generated SDK sets X-Api-Key above this transport, and Go copies
 		// caller-set headers across redirect hops. Only Authorization and a few
 		// others are stripped on a cross-host redirect, so drop the credential

--- a/cloudsmith/provider_config.go
+++ b/cloudsmith/provider_config.go
@@ -5,35 +5,55 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/cloudsmith-io/cloudsmith-api-go"
 	cloudsmithv2 "github.com/cloudsmith-io/cloudsmith-go-v2"
+	"github.com/cloudsmith-io/cloudsmith-go-v2/models/components"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 )
 
-var errMissingCredentials = errors.New("credentials required for Cloudsmith provider")
-
 type providerConfig struct {
-	// authentication credentials for the configured user
 	Auth context.Context
 
-	// initialised Cloudsmith API client
 	APIClient *cloudsmith.APIClient
 
 	V2ApiClient *cloudsmithv2.Cloudsmith
+
+	tokens tokenSource
 }
 
-func newProviderConfig(apiHost, apiKey string, headers map[string]interface{}, userAgent string) (*providerConfig, diag.Diagnostics) {
+func newProviderConfig(ctx context.Context, apiHost string, tokens tokenSource, headers map[string]interface{}, userAgent string) (*providerConfig, diag.Diagnostics) {
+	if tokens == nil {
+		return nil, diag.FromErr(errMissingCredentials)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	apiKey, err := tokens.Token(ctx)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
 	if apiKey == "" {
 		return nil, diag.FromErr(errMissingCredentials)
 	}
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Cloudsmith", &headerTransport{
-		headers: headers,
-		rt:      http.DefaultTransport,
-	})
+	credHost, err := credentialHost(apiHost)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
+	httpClient := &http.Client{
+		Transport: logging.NewSubsystemLoggingHTTPTransport("Cloudsmith", &headerTransport{
+			headers: headers,
+			rt: &apiKeyTransport{
+				tokens:  tokens,
+				apiHost: credHost,
+				rt:      http.DefaultTransport,
+			},
+		}),
+	}
 
 	config := cloudsmith.NewConfiguration()
 	config.Debug = logging.IsDebugOrHigher()
@@ -56,14 +76,18 @@ func newProviderConfig(apiHost, apiKey string, headers map[string]interface{}, u
 
 	req := apiClient.UserApi.UserSelf(auth)
 	if _, _, err := apiClient.UserApi.UserSelfExecute(req); err != nil {
-		return nil, diag.FromErr(errors.New("invalid API credentials"))
+		return nil, diag.FromErr(fmt.Errorf("invalid API credentials: %w", err))
 	}
 
 	v2Options := []cloudsmithv2.SDKOption{
 		cloudsmithv2.WithClient(httpClient),
-	}
-	if apiKey != "" {
-		v2Options = append(v2Options, cloudsmithv2.WithSecurity(apiKey))
+		cloudsmithv2.WithSecuritySource(func(ctx context.Context) (components.Security, error) {
+			tok, err := tokens.Token(ctx)
+			if err != nil {
+				return components.Security{}, err
+			}
+			return components.Security{Apikey: tok}, nil
+		}),
 	}
 	if apiHost != "" {
 		v2Options = append(v2Options, cloudsmithv2.WithServerURL(apiHost))
@@ -73,12 +97,20 @@ func newProviderConfig(apiHost, apiKey string, headers map[string]interface{}, u
 		Auth:        auth,
 		APIClient:   apiClient,
 		V2ApiClient: cloudsmithv2.New(v2Options...),
+		tokens:      tokens,
 	}, nil
 }
 
-func (pc *providerConfig) GetAPIKey() string {
+// GetAPIKey returns the current credential. A token-source failure is returned
+// rather than swallowed: falling back to the token minted at configure time
+// would send a known-expired credential and report the resulting rejection
+// instead of the refresh error that caused it.
+func (pc *providerConfig) GetAPIKey() (string, error) {
+	if pc.tokens != nil {
+		return pc.tokens.Token(context.Background())
+	}
 	apiKeys, _ := pc.Auth.Value(cloudsmith.ContextAPIKeys).(map[string]cloudsmith.APIKey)
-	return apiKeys["apikey"].Key
+	return apiKeys["apikey"].Key, nil
 }
 
 type headerTransport struct {
@@ -92,3 +124,94 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	return t.rt.RoundTrip(req)
 }
+
+type apiKeyTransport struct {
+	tokens  tokenSource
+	apiHost string
+	rt      http.RoundTripper
+}
+
+// credentialHost is the only host apiKeyTransport will send the Cloudsmith
+// credential to. An empty api_host yields an empty host, which disables the
+// restriction and keeps callers that pass no api_host working. A non-empty
+// api_host that is not absolute is rejected here rather than left to fail later
+// as an opaque "unsupported protocol scheme" from the round tripper.
+func credentialHost(apiHost string) (string, error) {
+	if apiHost == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(apiHost)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", errInvalidAPIHost
+	}
+	return parsed.Host, nil
+}
+
+func (t *apiKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The same client serves package downloads, which go to dl.cloudsmith.io
+	// and then redirect to third-party object storage. RoundTrip runs once per
+	// redirect hop, so without this check the credential would be re-stamped
+	// onto the storage host too and land in its access logs.
+	if t.apiHost != "" && req.URL.Host != t.apiHost {
+		// The generated SDK sets X-Api-Key above this transport, and Go copies
+		// caller-set headers across redirect hops. Only Authorization and a few
+		// others are stripped on a cross-host redirect, so drop the credential
+		// here as well. Authorization is left alone: package downloads send it
+		// to the CDN deliberately.
+		req.Header.Del("X-Api-Key")
+		return t.rt.RoundTrip(req)
+	}
+	used, err := t.setAPIKey(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.rt.RoundTrip(req)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized || t.tokens == nil || !t.tokens.canRetryAuth() {
+		return resp, err
+	}
+	retry, cloneErr := cloneHTTPRequest(req)
+	if cloneErr != nil {
+		// Cannot retry this one, but the token is still known-bad: drop it so
+		// the next request refreshes instead of reusing a dead token.
+		t.tokens.invalidate(used)
+		return resp, err
+	}
+	resp.Body.Close()
+	t.tokens.invalidate(used)
+	if _, err := t.setAPIKey(retry); err != nil {
+		return nil, err
+	}
+	return t.rt.RoundTrip(retry)
+}
+
+// setAPIKey stamps the current token on the request and reports which token was
+// used, so a 401 retry only invalidates that token and not a fresher one.
+func (t *apiKeyTransport) setAPIKey(req *http.Request) (string, error) {
+	if t.tokens == nil {
+		return "", nil
+	}
+	tok, err := t.tokens.Token(req.Context())
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-Api-Key", tok)
+	return tok, nil
+}
+
+func cloneHTTPRequest(req *http.Request) (*http.Request, error) {
+	clone := req.Clone(req.Context())
+	if req.Body == nil || req.Body == http.NoBody {
+		return clone, nil
+	}
+	if req.GetBody == nil {
+		return nil, errCannotReplayRequest
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	clone.Body = body
+	return clone, nil
+}
+
+var errCannotReplayRequest = errors.New("cannot retry OIDC auth: request body is not replayable")

--- a/cloudsmith/provider_config_transport_test.go
+++ b/cloudsmith/provider_config_transport_test.go
@@ -1,0 +1,209 @@
+package cloudsmith
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type rotatingTestTokenSource struct {
+	mu          sync.Mutex
+	current     string
+	next        string
+	invalidated []string
+}
+
+func (s *rotatingTestTokenSource) Token(context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.current, nil
+}
+
+func (s *rotatingTestTokenSource) invalidate(used string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.invalidated = append(s.invalidated, used)
+	if s.current == used {
+		s.current = s.next
+	}
+}
+
+func (s *rotatingTestTokenSource) canRetryAuth() bool { return true }
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestAPIKeyTransportStripsCredentialOutsideAPIEndpoint(t *testing.T) {
+	endpoint, err := credentialEndpointFor("https://api.example.com/v1")
+	if err != nil {
+		t.Fatalf("credential endpoint: %v", err)
+	}
+
+	for _, target := range []string{
+		"https://storage.example.com/package",
+		"http://api.example.com/v1/packages/",
+	} {
+		t.Run(target, func(t *testing.T) {
+			transport := &apiKeyTransport{
+				tokens:      staticToken("secret"),
+				apiEndpoint: endpoint,
+				rt: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if got := req.Header.Get("X-Api-Key"); got != "" {
+						t.Errorf("X-Api-Key = %q, want credential stripped", got)
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+				}),
+			}
+			req, err := http.NewRequest(http.MethodGet, target, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("X-Api-Key", "credential-set-by-sdk")
+
+			if _, err := transport.RoundTrip(req); err != nil {
+				t.Fatalf("round trip: %v", err)
+			}
+		})
+	}
+}
+
+func TestAPIKeyTransportStripsCredentialOnHTTPSDowngradeRedirect(t *testing.T) {
+	endpoint, err := credentialEndpointFor("https://api.example.com/v1")
+	if err != nil {
+		t.Fatalf("credential endpoint: %v", err)
+	}
+	calls := 0
+	client := &http.Client{Transport: &apiKeyTransport{
+		tokens:      staticToken("secret"),
+		apiEndpoint: endpoint,
+		rt: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			switch calls {
+			case 1:
+				if got := req.Header.Get("X-Api-Key"); got != "secret" {
+					t.Errorf("initial X-Api-Key = %q, want secret", got)
+				}
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"http://api.example.com/v1/packages/"}},
+					Body:       http.NoBody,
+					Request:    req,
+				}, nil
+			case 2:
+				if got := req.Header.Get("X-Api-Key"); got != "" {
+					t.Errorf("redirect X-Api-Key = %q, want credential stripped", got)
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+			default:
+				t.Fatalf("round trips = %d, want 2", calls)
+				return nil, nil
+			}
+		}),
+	}}
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1/packages/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client request: %v", err)
+	}
+	defer resp.Body.Close()
+	if calls != 2 {
+		t.Errorf("round trips = %d, want 2", calls)
+	}
+}
+
+func TestAPIKeyTransportRetriesUnauthorizedRequestWithBody(t *testing.T) {
+	tokens := &rotatingTestTokenSource{current: "old-token", next: "new-token"}
+	firstBody := &closeTrackingBody{Reader: strings.NewReader("unauthorized")}
+	var headers, bodies []string
+	transport := &apiKeyTransport{
+		tokens:      tokens,
+		apiEndpoint: credentialEndpoint{scheme: "https", host: "api.example.com"},
+		rt: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			headers = append(headers, req.Header.Get("X-Api-Key"))
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			bodies = append(bodies, string(body))
+			if len(headers) == 1 {
+				return &http.Response{StatusCode: http.StatusUnauthorized, Body: firstBody}, nil
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/packages/", strings.NewReader("request-body"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got, want := strings.Join(headers, ","), "old-token,new-token"; got != want {
+		t.Errorf("credentials = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(bodies, ","), "request-body,request-body"; got != want {
+		t.Errorf("bodies = %q, want %q", got, want)
+	}
+	if !firstBody.closed {
+		t.Error("first response body was not closed before retry")
+	}
+	if got, want := strings.Join(tokens.invalidated, ","), "old-token"; got != want {
+		t.Errorf("invalidated tokens = %q, want %q", got, want)
+	}
+}
+
+func TestAPIKeyTransportDoesNotRetryNonReplayableBody(t *testing.T) {
+	tokens := &rotatingTestTokenSource{current: "old-token", next: "new-token"}
+	calls := 0
+	transport := &apiKeyTransport{
+		tokens:      tokens,
+		apiEndpoint: credentialEndpoint{scheme: "https", host: "api.example.com"},
+		rt: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{StatusCode: http.StatusUnauthorized, Body: http.NoBody}, nil
+		}),
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/packages/", io.NopCloser(strings.NewReader("request-body")))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if calls != 1 {
+		t.Errorf("round trips = %d, want 1", calls)
+	}
+	if got, want := strings.Join(tokens.invalidated, ","), "old-token"; got != want {
+		t.Errorf("invalidated tokens = %q, want %q", got, want)
+	}
+}

--- a/cloudsmith/provider_test.go
+++ b/cloudsmith/provider_test.go
@@ -186,7 +186,7 @@ func TestProviderConfig_V2UsesAPIKeyAndHost(t *testing.T) {
 	}))
 	defer server.Close()
 
-	pc, diags := newProviderConfig(server.URL, "valid-token", map[string]interface{}{}, "test-agent")
+	pc, diags := newProviderConfig(context.Background(), server.URL, staticToken("valid-token"), map[string]interface{}{}, "test-agent")
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}

--- a/cloudsmith/resource_repository_delete_test.go
+++ b/cloudsmith/resource_repository_delete_test.go
@@ -2,6 +2,7 @@
 package cloudsmith
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -68,8 +69,9 @@ func testAccAPIClient(t *testing.T) *providerConfig {
 	}
 
 	pc, diags := newProviderConfig(
+		context.Background(),
 		apiHost,
-		os.Getenv("CLOUDSMITH_API_KEY"),
+		staticToken(os.Getenv("CLOUDSMITH_API_KEY")),
 		nil,
 		"terraform-provider-cloudsmith-acctest",
 	)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsmith-io/terraform-provider-cloudsmith
 go 1.26
 
 require (
-	github.com/cloudsmith-io/cloudsmith-api-go v0.0.60
+	github.com/cloudsmith-io/cloudsmith-api-go v0.0.62
 	github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.60 h1:H1qn16Se4vOKoqaD0yYlI/8/DHMfqEBO6I3Ky6ejBxo=
-github.com/cloudsmith-io/cloudsmith-api-go v0.0.60/go.mod h1:xHTDgU8TyMXiWUZdn2OQR7AaZdz9M5SrNenyQU44zGQ=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.62 h1:hnGfc8eJqeHoFvyeLLCmOp8YWkjqqisZlhsjhBMCkIs=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.62/go.mod h1:xHTDgU8TyMXiWUZdn2OQR7AaZdz9M5SrNenyQU44zGQ=
 github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523 h1:zpwbcGnLwreE18qP6lYD5z9s36BZF/4va1Rc3tApgyQ=
 github.com/cloudsmith-io/cloudsmith-go-v2 v0.0.0-20260602111530-3868b1d47523/go.mod h1:yjFP2n2rHMRsL44JdJUqh+iEWqHKrbttEmDyIGllVDY=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=


### PR DESCRIPTION
# Description

HCP Terraform workspaces can now authenticate the provider without storing a long-lived Cloudsmith API key. The provider exchanges the workload identity token from the run environment for a short-lived Cloudsmith credential. Existing API key configuration continues to work as before.

OIDC must be enabled with an `oidc` block or `CLOUDSMITH_USE_OIDC=true`. The provider refreshes exchanged credentials before expiry and retries one API request after a 401. It only sends `X-Api-Key` to the configured Cloudsmith API host, so package storage redirects cannot inherit the credential.

```hcl
provider "cloudsmith" {
  oidc {
    organization = "your-organization"
    service_slug  = "your-service-account"
  }
}
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tests
- [ ] Other (please describe)

## Testing

```bash
go test ./...
```

## Additional Notes

This is the bottom layer of the OIDC stack. The next PR adds the OIDC behavior and security tests. The final PR adds the documentation and example.
