### PR TITLE
docs: document HCP Terraform OIDC authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+* **provider:** OIDC authentication for HCP Terraform (Terraform Cloud). Enable it with an `oidc` block or `CLOUDSMITH_USE_OIDC=true`; the provider reads the workspace's workload identity token, exchanges it for a Cloudsmith token, refreshes that token before expiry, and retries once on 401. No `local-exec` or `external` data source needed. Other CI platforms are not supported yet. ([#128](https://github.com/cloudsmith-io/terraform-provider-cloudsmith/issues/128))

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ To use a released provider in your Terraform environment, run [`terraform init`]
 
 To instead use a custom-built provider in your Terraform environment (e.g. the provider binary from the build instructions above), follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-plugins) After placing the custom-built provider into your plugins directory, run `terraform init` to initialize it.
 
+### Authenticate with OIDC
+
+Authenticate with a Cloudsmith OIDC service account instead of a static API key. Only HCP Terraform (Terraform Cloud) workload identity is supported for now. Use an `oidc` block, or set `CLOUDSMITH_USE_OIDC=true`, and do not set `api_key` in HCL. The provider reads the workload identity token HCP Terraform injects into the run (`TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH`, then `TFC_WORKLOAD_IDENTITY_TOKEN`) and exchanges it for a short-lived Cloudsmith token. Full setup, including the workspace-side `TFC_WORKLOAD_IDENTITY_AUDIENCE` variable, is in `docs/index.md`.
+
+```hcl
+provider "cloudsmith" {
+    oidc {
+        organization = "acme-org"
+        service_slug = "tfc-prod"
+    }
+}
+```
+
+You can omit `organization` and `service_slug` when `CLOUDSMITH_ORG` and `CLOUDSMITH_SERVICE_SLUG` are set. An empty `provider "cloudsmith" {}` block does not enable OIDC unless `CLOUDSMITH_USE_OIDC` is true. An `oidc` block ignores a leftover `CLOUDSMITH_API_KEY`.
+
 ### Examples
 
 Create a repository with a custom entitlement token

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,46 @@ resource "cloudsmith_entitlement" "my_entitlement" {
 }
 ```
 
+## Authenticate with OIDC
+
+Authenticate the provider with a Cloudsmith OIDC service account instead of a static API key. **Only HCP Terraform (Terraform Cloud) workload identity is supported for now** - other CI platforms are planned but not implemented, so use `api_key` there.
+
+Enable it with an `oidc` block, or by setting `CLOUDSMITH_USE_OIDC=true`. Do not set `api_key` in HCL. The identity token is never an argument and never lands in Terraform state.
+
+This is provider *login*. It is not the [`cloudsmith_oidc`](resources/oidc.md) resource, which configures which identity providers Cloudsmith trusts and which claims a token must carry (including the `aud` your token is issued for). You still create that trust - with the resource, or in the Cloudsmith UI - before Terraform can exchange a token.
+
+An `oidc` block (or `CLOUDSMITH_USE_OIDC`) ignores a leftover `CLOUDSMITH_API_KEY` environment variable, so an existing workspace can migrate without removing it first. An `api_key` argument in HCL still conflicts with `oidc`. An empty `provider "cloudsmith" {}` block does not enable OIDC unless `CLOUDSMITH_USE_OIDC` is true.
+
+The provider reads the identity token from `TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH`, then `TFC_WORKLOAD_IDENTITY_TOKEN`. It POSTs that token to the OpenID endpoint derived from `api_host` (the default production endpoint is `https://api.cloudsmith.io/openid/{organization}/`) and uses the returned Cloudsmith JWT as `X-Api-Key`. The JWT is refreshed a minute before its `exp` claim, or every 15 minutes if it carries no readable expiry. If a request still comes back 401, the provider discards that token, exchanges a fresh one, and replays the request once.
+
+You can omit `organization` and `service_slug` when `CLOUDSMITH_ORG` and `CLOUDSMITH_SERVICE_SLUG` are set.
+
+```hcl
+provider "cloudsmith" {
+    oidc {
+        organization = "acme-org"
+        service_slug = "tfc-prod"
+    }
+}
+```
+
+### HCP Terraform / Terraform Cloud setup
+
+This replaces the `local-exec` and `data.external` workarounds previously needed to get a Cloudsmith token into a run.
+
+1. In Cloudsmith, create a service account, then an OIDC provider for `https://app.terraform.io`. Require claims that match the workspace, at least `aud` and `terraform_organization_name`.
+2. On the HCP Terraform workspace, set `TFC_WORKLOAD_IDENTITY_AUDIENCE` as an **environment** variable (not a Terraform variable) to the same `aud` value you configured in Cloudsmith, for example `cloudsmith`. HCP Terraform then injects `TFC_WORKLOAD_IDENTITY_TOKEN` into the run. To keep a Cloudsmith-specific audience alongside others, set `TFC_WORKLOAD_IDENTITY_AUDIENCE_CLOUDSMITH` instead and the token arrives as `TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH`, which the provider prefers.
+3. Configure the provider with the `oidc` block shown above, or set `CLOUDSMITH_USE_OIDC=true` together with `CLOUDSMITH_ORG` and `CLOUDSMITH_SERVICE_SLUG`.
+4. Do not set `api_key` in HCL. A leftover `CLOUDSMITH_API_KEY` workspace variable is ignored, but delete it once the run works if you no longer want a static key in the workspace.
+
+The identity token `aud` must match the `aud` claim on the Cloudsmith OIDC provider. If they disagree the exchange fails with a 401 and no Cloudsmith token is issued.
+
+See [Manually generate workload identity tokens](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/manual-generation) and [Cloudsmith OpenID Connect](https://docs.cloudsmith.com/authentication/openid-connect).
+
 ## Argument Reference
 
-* `api_key` - (Required) The API key for authenticating with the Cloudsmith API.
+* `api_key` - (Optional) The API key for authenticating with the Cloudsmith API. If you omit it and set neither `oidc` nor `CLOUDSMITH_USE_OIDC`, the provider reads `CLOUDSMITH_API_KEY`. Conflicts with `oidc`.
 * `api_host` - (Optional) The API host to connect to (used to connect to a non-production Cloudsmith instance, mostly useful for testing).
+* `oidc` - (Optional) Authenticate with a Cloudsmith OIDC service account using an HCP Terraform workload identity token. Conflicts with `api_key`. The identity token is not an argument. Ignores a leftover `CLOUDSMITH_API_KEY`. Equivalent env: `CLOUDSMITH_USE_OIDC=true`.
+  * `organization` - Organization slug. Defaults to `CLOUDSMITH_ORG`.
+  * `service_slug` - Service account slug. Defaults to `CLOUDSMITH_SERVICE_SLUG`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,9 +37,11 @@ Enable it with an `oidc` block, or by setting `CLOUDSMITH_USE_OIDC=true`. Do not
 
 This is provider *login*. It is not the [`cloudsmith_oidc`](resources/oidc.md) resource, which configures which identity providers Cloudsmith trusts and which claims a token must carry (including the `aud` your token is issued for). You still create that trust - with the resource, or in the Cloudsmith UI - before Terraform can exchange a token.
 
+Terraform configures a provider before it creates any resource, so an OIDC-only configuration cannot create its own trust in the same apply: the exchange runs first and fails. Create the trust in the Cloudsmith UI, or apply `cloudsmith_oidc` in an earlier run with a static `api_key`, and only then migrate the provider to `oidc`.
+
 An `oidc` block (or `CLOUDSMITH_USE_OIDC`) ignores a leftover `CLOUDSMITH_API_KEY` environment variable, so an existing workspace can migrate without removing it first. An `api_key` argument in HCL still conflicts with `oidc`. An empty `provider "cloudsmith" {}` block does not enable OIDC unless `CLOUDSMITH_USE_OIDC` is true.
 
-The provider reads the identity token from `TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH`, then `TFC_WORKLOAD_IDENTITY_TOKEN`. It POSTs that token to the OpenID endpoint derived from `api_host` (the default production endpoint is `https://api.cloudsmith.io/openid/{organization}/`) and uses the returned Cloudsmith JWT as `X-Api-Key`. The JWT is refreshed a minute before its `exp` claim, or every 15 minutes if it carries no readable expiry. If a request still comes back 401, the provider discards that token, exchanges a fresh one, and replays the request once.
+The provider reads the identity token from `TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH`, then `TFC_WORKLOAD_IDENTITY_TOKEN`. It POSTs that token to the OpenID endpoint derived from `api_host` (the default production endpoint is `https://api.cloudsmith.io/openid/{organization}/`) and uses the returned Cloudsmith JWT as `X-Api-Key`. The JWT is refreshed a minute before its `exp` claim. A token with no readable expiry - an opaque token, for example - is treated as a 15 minute credential and so refreshed after about 14 minutes. If a request still comes back 401, the provider discards that token; the request is replayed once with a freshly exchanged token when its body can be replayed, otherwise the original 401 is returned and the next request picks up a new token.
 
 You can omit `organization` and `service_slug` when `CLOUDSMITH_ORG` and `CLOUDSMITH_SERVICE_SLUG` are set.
 
@@ -56,7 +58,7 @@ provider "cloudsmith" {
 
 This replaces the `local-exec` and `data.external` workarounds previously needed to get a Cloudsmith token into a run.
 
-1. In Cloudsmith, create a service account, then an OIDC provider for `https://app.terraform.io`. Require claims that match the workspace, at least `aud` and `terraform_organization_name`.
+1. In Cloudsmith, create a service account, then an OIDC provider for `https://app.terraform.io` that lists that service account as a permitted one (`service_accounts = ["tfc-prod"]` on `cloudsmith_oidc`, or the equivalent selection in the UI). Without that association the exchange has no service account to issue a token for. Require claims that match the workspace, at least `aud` and `terraform_organization_name`.
 2. On the HCP Terraform workspace, set `TFC_WORKLOAD_IDENTITY_AUDIENCE` as an **environment** variable (not a Terraform variable) to the same `aud` value you configured in Cloudsmith, for example `cloudsmith`. HCP Terraform then injects `TFC_WORKLOAD_IDENTITY_TOKEN` into the run. To keep a Cloudsmith-specific audience alongside others, set `TFC_WORKLOAD_IDENTITY_AUDIENCE_CLOUDSMITH` instead and the token arrives as `TFC_WORKLOAD_IDENTITY_TOKEN_CLOUDSMITH`, which the provider prefers.
 3. Configure the provider with the `oidc` block shown above, or set `CLOUDSMITH_USE_OIDC=true` together with `CLOUDSMITH_ORG` and `CLOUDSMITH_SERVICE_SLUG`.
 4. Do not set `api_key` in HCL. A leftover `CLOUDSMITH_API_KEY` workspace variable is ignored, but delete it once the run works if you no longer want a static key in the workspace.

--- a/examples/oidc-auth/provider.tf
+++ b/examples/oidc-auth/provider.tf
@@ -1,0 +1,16 @@
+# tflint-ignore-file: terraform_required_version, terraform_required_providers
+
+terraform {
+  required_providers {
+    cloudsmith = {
+      source = "cloudsmith-io/cloudsmith"
+    }
+  }
+}
+
+provider "cloudsmith" {
+  oidc {
+    organization = "acme-org"
+    service_slug = "tfc-prod"
+  }
+}


### PR DESCRIPTION
# Description

Documents how to configure HCP Terraform workload identity authentication on both the Cloudsmith and workspace sides. It covers provider configuration, environment-variable fallbacks, token refresh behavior, migration from static API keys, and the distinction between provider login and the `cloudsmith_oidc` resource.

```hcl
provider "cloudsmith" {
  oidc {
    organization = "your-organization"
    service_slug  = "your-service-account"
  }
}
```

Also adds a minimal provider example and an unreleased changelog entry.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Tests
- [ ] Other (please describe)

## Testing

```bash
terraform fmt -check -diff examples/oidc-auth/provider.tf
```

## Additional Notes

Final layer of the OIDC stack, based on #227. No provider behavior changes are included.
